### PR TITLE
FF-46: cards "how we work" desktop

### DIFF
--- a/frontend-react/components/desktop/layout/HowWeWorkDesktop/HowWeWorkDesktop.tsx
+++ b/frontend-react/components/desktop/layout/HowWeWorkDesktop/HowWeWorkDesktop.tsx
@@ -9,21 +9,21 @@ const HowWeWorkDesktop: React.FC = () => {
                 <div className="mb-[122px]">
                     <TitleDesktop title="Как мы работаем" href="#" />
                 </div>
-                <div className="3xl:gap-8 flex flex-row items-center gap-10 2xl:gap-5">
+                <div className="flex items-center justify-between gap-[clamp(20px,_2vw,_40px)]">
                     {content.map((item) => (
                         <div
                             key={item.id}
-                            className="relative flex min-h-60 w-[400px] flex-col items-center rounded-[22px] bg-[#ffffff1a] px-5 pt-[80px] text-center 2xl:pt-[60px]"
+                            className="relative flex h-[264px] w-[418px] flex-col items-center rounded-[22px] bg-[#ffffff1a] px-[20px] pt-[80px] text-center 2xl:h-[250px] 2xl:pt-[60px]"
                         >
                             <div className="3xl:top-[-40px] absolute top-[-50px] rounded-full border-8 border-[#101030] 2xl:top-[-40px]">
                                 <div className="bg-gradient-desktop 3xl:size-[75px] flex size-[85px] items-center justify-center rounded-full bg-[#101030] 2xl:size-[70px]">
                                     {item.icon}
                                 </div>
                             </div>
-                            <h3 className="text28px_desktop text-gradient_desktop_custom relative mb-[12px] font-medium uppercase">
+                            <h3 className="text28px_desktop text-gradient_desktop_custom relative mb-[10px] font-medium uppercase">
                                 {item.title}
                             </h3>
-                            <div className="text18px_desktop text-center font-medium text-[#878797]">
+                            <div className="text18px_desktop text-center font-medium leading-tight text-[#878797]">
                                 {item.description.map((item, index) => (
                                     <p key={index}>{item}</p>
                                 ))}


### PR DESCRIPTION
Изменила свойства для карточек блока "Как мы работаем" и их родительскому контейнеру для десктопа.

**Desktop**
  * 1920px
![image](https://github.com/user-attachments/assets/9ed47cb5-e1e4-4c93-9026-af11d03a6b90)

  * 4xl
![image](https://github.com/user-attachments/assets/94c5be55-cef1-43ce-80c8-61d96d303ebe)

  * 3xl
![image](https://github.com/user-attachments/assets/ed9aaf58-3858-463b-9190-0aff5fd2ddf7)

  * 2xl
![image](https://github.com/user-attachments/assets/bde8976d-6db7-4837-bb74-ae652b72a4d8)


