### PR TITLE
FF-47 fix title desktop

### DIFF
--- a/frontend-react/components/desktop/shared/TitleDesktop.tsx
+++ b/frontend-react/components/desktop/shared/TitleDesktop.tsx
@@ -9,7 +9,7 @@ const TitleDesktop: React.FC<PropsTitleDesktop> = ({ title, href }) => {
     return (
         <div className="relative">
             <h2
-                className="4xl:text-[7.5rem] 3xl:bottom-[-8px] 3xl:text-[7rem] absolute bottom-0 z-0 text-[160px] font-semibold uppercase leading-none text-white opacity-[2%] 2xl:text-[96px]"
+                className="4xl:text-[7.5rem] 3xl:text-[7rem] absolute bottom-0 z-0 text-[160px] font-semibold uppercase leading-none text-white opacity-[2%] 2xl:text-[96px]"
                 style={{
                     lineHeight: 0.76,
                     marginLeft: '-0.1em',

--- a/frontend-react/components/desktop/shared/TitleDesktop.tsx
+++ b/frontend-react/components/desktop/shared/TitleDesktop.tsx
@@ -8,11 +8,23 @@ interface PropsTitleDesktop {
 const TitleDesktop: React.FC<PropsTitleDesktop> = ({ title, href }) => {
     return (
         <div className="relative">
-            <h2 className="4xl:text-[7.5rem] 3xl:bottom-[-8px] 3xl:text-[7rem] absolute bottom-[-7px] left-[-15px] z-0 text-[160px] font-semibold uppercase leading-none text-white opacity-[2%] 2xl:bottom-[-4px] 2xl:text-[96px]">
+            <h2
+                className="4xl:text-[7.5rem] 3xl:bottom-[-8px] 3xl:text-[7rem] absolute bottom-0 z-0 text-[160px] font-semibold uppercase leading-none text-white opacity-[2%] 2xl:text-[96px]"
+                style={{
+                    lineHeight: 0.76,
+                    marginLeft: '-0.1em',
+                }}
+            >
                 {title}
             </h2>
             <Link href={href}>
-                <h2 className="4xl:text-27xl 3xl:text-25xl 2xl:text-21xl hover:bg-gradient-desktop relative left-[-7px] z-10 text-[80px] font-medium uppercase leading-none text-white hover:bg-clip-text hover:text-transparent">
+                <h2
+                    className="4xl:text-27xl 3xl:text-25xl 2xl:text-21xl hover:bg-gradient-desktop relative z-10 w-fit text-[80px] font-medium uppercase leading-none text-white hover:bg-clip-text hover:text-transparent"
+                    style={{
+                        lineHeight: 0.8,
+                        marginLeft: '-0.1em',
+                    }}
+                >
                     {title}
                 </h2>
             </Link>


### PR DESCRIPTION
Прировняла текст заголовков h2 для titleDesktop, убрала внутренние отступы, которые задавались самим шрифтом Монсерат

* 1920px
![image](https://github.com/user-attachments/assets/db3eb34e-f43d-4147-bc4f-53a1840795b8)
![image](https://github.com/user-attachments/assets/fb584087-509d-4b9f-9245-1045d742fe76)
![image](https://github.com/user-attachments/assets/7a979a15-31e2-4b9f-9b5f-423a266b517e)

* 4xl
![image](https://github.com/user-attachments/assets/4ae5f7e3-d29c-41dd-b1bb-1b9c934ec0f1)
![image](https://github.com/user-attachments/assets/319169d3-0fa5-40db-ba84-48307bfde002)
![image](https://github.com/user-attachments/assets/92e5fbb8-e8ab-4820-9570-b8d12fb76b41)

* 3xl
![image](https://github.com/user-attachments/assets/a8fe1940-b34c-4d2b-aed2-802ee3b03990)
![image](https://github.com/user-attachments/assets/b5f21f55-8acc-45ca-b369-f75924ce2687)
![image](https://github.com/user-attachments/assets/5f36a5ca-1050-4c30-b9c4-1eeb99f46ce0)

* 2xl
![image](https://github.com/user-attachments/assets/9955916b-8570-4fff-8007-3ced369d2d17)
![image](https://github.com/user-attachments/assets/c5a52a65-eb1f-4801-a778-4fc6d6b746cb)
![image](https://github.com/user-attachments/assets/c949fa97-c211-4006-a759-c47dbc7a98eb)
