### PR TITLE
FF-71-fix Header margins

### DIFF
--- a/frontend-react/app/contacts/page.tsx
+++ b/frontend-react/app/contacts/page.tsx
@@ -35,6 +35,7 @@ export default function Contacts() {
                 </>
             ) : (
                 <>
+                    <div className="h-[20px] bg-[#101030]"> </div>
                     <HeaderMobi />
                     <main className="bg-[#101030] text-white">
                         <ContactsPageMobi />

--- a/frontend-react/app/profevents/page.tsx
+++ b/frontend-react/app/profevents/page.tsx
@@ -33,6 +33,7 @@ export default function Profevents() {
                 </>
             ) : (
                 <>
+                    <div className="h-[20px] bg-[#101030]"></div>
                     <HeaderMobi />
                     <main className="bg-[#101030] text-white">
                         <h1>Prof events</h1>

--- a/frontend-react/app/profile/page.tsx
+++ b/frontend-react/app/profile/page.tsx
@@ -34,6 +34,7 @@ export default function Profile() {
                 </>
             ) : (
                 <>
+                    <div className="h-[20px] bg-[#101030]"></div>
                     <HeaderMobi />
                     <main className="bg-[#101030] text-white">
                         <h1>Личный профиль</h1>

--- a/frontend-react/components/mobi/layout/HeaderMobi/HeaderMobi.tsx
+++ b/frontend-react/components/mobi/layout/HeaderMobi/HeaderMobi.tsx
@@ -60,7 +60,7 @@ const HeaderMobi: React.FC<HeaderMobiProps> = ({ disableBackground }) => {
                 }
             >
                 <div
-                    className={`relative flex h-[56px] w-full px-[15px] items-center justify-between ${!disableBackground ? 'container' : ''}`}
+                    className={`relative flex h-[56px] w-full px-[15px] items-center justify-between`}
                 >
                     <PhoneIconMobi className="cursor-pointer" />
                     <div className="absolute left-1/2 top-7 -translate-x-1/2 -translate-y-1/2">

--- a/frontend-react/components/mobi/layout/HeaderMobi/HeaderMobi.tsx
+++ b/frontend-react/components/mobi/layout/HeaderMobi/HeaderMobi.tsx
@@ -60,13 +60,13 @@ const HeaderMobi: React.FC<HeaderMobiProps> = ({ disableBackground }) => {
                 }
             >
                 <div
-                    className={`relative flex h-[56px] w-full items-center justify-between ${!disableBackground ? 'container' : ''}`}
+                    className={`relative flex h-[56px] w-full px-[15px] items-center justify-between ${!disableBackground ? 'container' : ''}`}
                 >
-                    <PhoneIconMobi className="ml-3 cursor-pointer" />
+                    <PhoneIconMobi className="cursor-pointer" />
                     <div className="absolute left-1/2 top-7 -translate-x-1/2 -translate-y-1/2">
                         <LogoIconMobi />
                     </div>
-                    <div className="mr-2 flex gap-[17px]">
+                    <div className="flex gap-[17px]">
                         <ShoppingCartIconMobi className="shrink-0 cursor-pointer" />
                         <BurgerMenuIconMobi className="shrink-0 cursor-pointer" onClick={toggleMenu} />
                     </div>


### PR DESCRIPTION
1. На странице Профессии в header уменьшила отступы слева и справа в соответствии с остальным контентом на странице (моб.версия).
<img width="431" alt="Снимок экрана 2025-01-30 в 22 35 02" src="https://github.com/user-attachments/assets/28bd03c4-f4ed-4b32-b6c9-d0037ef8b7f1" />

2. На страницах Свяжитесь с нами, Мероприятия, Личный кабинет аналогично исправила отступы в header. Кроме того, на указанные страницы добавила отступ сверху (моб.версия).
<img width="418" alt="Снимок экрана 2025-01-30 в 22 44 42" src="https://github.com/user-attachments/assets/c243e906-aac6-4df0-8c1e-e106ca42d82b" />
<img width="399" alt="Снимок экрана 2025-01-30 в 23 26 29" src="https://github.com/user-attachments/assets/f9d5905f-40b4-427e-b7fd-3aa54e8a3259" />
<img width="417" alt="Снимок экрана 2025-01-30 в 22 44 11" src="https://github.com/user-attachments/assets/5a46e724-04f3-4a11-bb79-acdb32411dd3" />

