### PR TITLE
FF-84 Fix cards layout desktop

### DIFF
--- a/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardsDesktop.tsx
+++ b/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardsDesktop.tsx
@@ -6,7 +6,7 @@ import HeaderCardItemDesktop from './HeaderCardItemDesktop'
 const HeaderCardsDesktop: React.FC = () => {
     return (
         <>
-            <div className="flex flex-col gap-[20px] md:gap-[12px] self-end">
+            <div className="flex flex-col gap-[20px] md:gap-[12px] self-end pt-[104px]">
                 <HeaderCardItemDesktop
                     textBlack="Стажировка"
                     textColor="наблюдателя"

--- a/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardsDesktop.tsx
+++ b/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardsDesktop.tsx
@@ -6,7 +6,7 @@ import HeaderCardItemDesktop from './HeaderCardItemDesktop'
 const HeaderCardsDesktop: React.FC = () => {
     return (
         <>
-            <div className="flex flex-col gap-[20px] md:gap-[12px] self-end pt-[104px]">
+            <div className="flex flex-col gap-[20px] md:gap-[12px] self-end pt-[104px] 2xl:pt-[75px]">
                 <HeaderCardItemDesktop
                     textBlack="Стажировка"
                     textColor="наблюдателя"

--- a/frontend-react/styles/customClasses/customClassElements.css
+++ b/frontend-react/styles/customClasses/customClassElements.css
@@ -112,7 +112,7 @@
         @apply shadow-shadow-right-desktop-custom;
     }
     .paddings-desktop-custom {
-        @apply pt-[10vw] pb-[50px] 3xl:pt-[7.5vw] 2xl:pt-[3.75rem] 2xl:pb-[3.75rem] xl:py-[2.5rem] lg:py-[2rem];
+        @apply pt-[15vw] pb-[50px] 3xl:pt-[7.5vw] 2xl:pt-[3.75rem] 2xl:pb-[3.75rem] xl:py-[2.5rem] lg:py-[2rem];
     }
     .gradient-text-desktop-custom {
         @apply bg-gradient-desktop bg-clip-text text-[1.5625rem] font-semibold text-transparent 2xl:text-[1.375rem];

--- a/frontend-react/styles/customClasses/customClassElements.css
+++ b/frontend-react/styles/customClasses/customClassElements.css
@@ -112,7 +112,7 @@
         @apply shadow-shadow-right-desktop-custom;
     }
     .paddings-desktop-custom {
-        @apply pt-[15vw] pb-[50px] 3xl:pt-[7.5vw] 2xl:pt-[3.75rem] 2xl:pb-[3.75rem] xl:py-[2.5rem] lg:py-[2rem];
+        @apply pt-[10vw] pb-[50px] 3xl:pt-[7.5vw] 2xl:pt-[3.75rem] 2xl:pb-[3.75rem] xl:py-[2.5rem] lg:py-[2rem];
     }
     .gradient-text-desktop-custom {
         @apply bg-gradient-desktop bg-clip-text text-[1.5625rem] font-semibold text-transparent 2xl:text-[1.375rem];


### PR DESCRIPTION
### Проблема, которая была решена:
- Карточки неправильно располагались при просмотре на десктопах

### Что было сделано:
- Исправлено расположение карточек на главной странице для десктопной версии.

До: 

![telegram-cloud-photo-size-2-5262825880118488396-y](https://github.com/user-attachments/assets/f42217b9-ece0-4a1e-ae6b-e681944ef775)


Пример правильного положения на макете :

<img width="651" alt="Снимок экрана 2025-02-04 в 17 51 34" src="https://github.com/user-attachments/assets/494ab4c9-9608-4d21-989a-9fe7cbacbd90" />


Результат :

1) 1240рх
<img width="628" alt="Снимок экрана 2025-02-04 в 19 28 17" src="https://github.com/user-attachments/assets/8f839a25-8388-473a-a97c-560f31853233" />


2) 1440рх
<img width="722" alt="Снимок экрана 2025-02-04 в 19 28 47" src="https://github.com/user-attachments/assets/04f385b6-ab4b-4cf1-ab9a-cd0780e4cc21" />



3) 1560рх
<img width="798" alt="Снимок экрана 2025-02-04 в 17 43 26" src="https://github.com/user-attachments/assets/eecd389d-462e-4d98-9f10-e3620f646798" />

4) 1920рх
<img width="983" alt="Снимок экрана 2025-02-04 в 17 44 34" src="https://github.com/user-attachments/assets/09fa013c-75e9-4f1b-97ce-1a8fce4689c7" />
