### PR TITLE
FF-91 connect registration modal for button on desktop version

### DIFF
--- a/frontend-react/components/desktop/layout/PromoDesktop/PromoDesktop.tsx
+++ b/frontend-react/components/desktop/layout/PromoDesktop/PromoDesktop.tsx
@@ -1,8 +1,15 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Button } from '@/components/ui/button'
 import { ArrowBtn } from '@/components/assets/icons'
+import { useModal } from '@/context/ContextModal'
 
 const PromoDesktop: React.FC = () => {
+    const { openModal } = useModal()
+
+    const handleOpenModal = () => {
+        openModal('registration_desktop', 'desktop')
+    }
+
     return (
         <div
             style={{
@@ -21,12 +28,12 @@ const PromoDesktop: React.FC = () => {
                     </p>
                 </div>
                 <div className="ml-8 flex justify-center lg:mt-10 xl:mt-10">
-                    <Button variant="registration" size="four_xl">
+                    <Button variant="registration" size="four_xl" onClick={handleOpenModal}>
                         <span className="bg-gradient-to-r from-[#8333F3] to-[#3B51A8] bg-clip-text text-transparent">
                             Зарегистрироваться
                         </span>
                     </Button>
-                    <Button variant="arrow" size="four_xl">
+                    <Button variant="arrow" size="four_xl" onClick={handleOpenModal}>
                         <ArrowBtn width={54} height={54} />
                     </Button>
                 </div>

--- a/frontend-react/components/desktop/layout/PromoDesktop/PromoDesktop.tsx
+++ b/frontend-react/components/desktop/layout/PromoDesktop/PromoDesktop.tsx
@@ -23,7 +23,6 @@ const PromoDesktop: React.FC = () => {
                         опыта и навыков
                     </p>
                 </div>
-
                 <div className="group ml-8 inline-flex w-fit items-center lg:mt-10 xl:mt-10">
                     <Button
                         variant="registration"

--- a/frontend-react/components/desktop/layout/PromoDesktop/PromoDesktop.tsx
+++ b/frontend-react/components/desktop/layout/PromoDesktop/PromoDesktop.tsx
@@ -1,14 +1,10 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { Button } from '@/components/ui/button'
 import { ArrowBtn } from '@/components/assets/icons'
 import { useModal } from '@/context/ContextModal'
 
 const PromoDesktop: React.FC = () => {
     const { openModal } = useModal()
-
-    const handleOpenModal = () => {
-        openModal('registration_desktop', 'desktop')
-    }
 
     return (
         <div
@@ -28,12 +24,20 @@ const PromoDesktop: React.FC = () => {
                     </p>
                 </div>
                 <div className="ml-8 flex justify-center lg:mt-10 xl:mt-10">
-                    <Button variant="registration" size="four_xl" onClick={handleOpenModal}>
+                    <Button
+                        variant="registration"
+                        size="four_xl"
+                        onClick={(): void => openModal('registration_desktop', 'desktop')}
+                    >
                         <span className="bg-gradient-to-r from-[#8333F3] to-[#3B51A8] bg-clip-text text-transparent">
                             Зарегистрироваться
                         </span>
                     </Button>
-                    <Button variant="arrow" size="four_xl" onClick={handleOpenModal}>
+                    <Button
+                        variant="arrow"
+                        size="four_xl"
+                        onClick={(): void => openModal('registration_desktop', 'desktop')}
+                    >
                         <ArrowBtn width={54} height={54} />
                     </Button>
                 </div>


### PR DESCRIPTION
### Добавлена возможность открытия модального окна при клике на кнопку "Зарегестрироваться" в компоненте PromoDesktop.

<p align="center">
  <img width="890" alt="Снимок экрана 2025-02-07 в 18 29 45" src="https://github.com/user-attachments/assets/365aef6c-ab02-4ebf-9a3c-0a87d38a6696" />
</p>

<p align="center">
  <img width="706" alt="Снимок экрана 2025-02-07 в 18 29 36" src="https://github.com/user-attachments/assets/1a9e6347-07ba-4fcb-ba83-5c5ed4ca3d33" />
</p>
