### PR TITLE
FF-109-fix-bg-HeaderDesktop fix: bg stretch full width

### DIFF
--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/HomePageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/HomePageDesktop.tsx
@@ -9,9 +9,11 @@ const HomePageDesktop: React.FC = () => {
     return (
         <>
             <div>
-                <div className="paddings-desktop-custom container flex justify-between bg-header-main-gradient-desktop">
-                    <HeaderMainDesktop />
-                    <HeaderCardsDesktop />
+                <div className="bg-header-main-gradient-desktop">
+                    <div className="paddings-desktop-custom container flex justify-between">
+                        <HeaderMainDesktop />
+                        <HeaderCardsDesktop />
+                    </div>
                 </div>
                 <HowWeWorkDesktop />
                 <ProfessionsSectionDesktop />


### PR DESCRIPTION
1. Контейнер с градиентом в компоненте HomePageDesktop. Создала новый див, перенесла в него градиент, т.о. по бокам нет отступов при растягивании на экран больше 1920px. 
![bg](https://github.com/user-attachments/assets/2c8a4d38-574d-4e84-84b4-49845f834d8f)
