### PR TITLE
FF-104-fix-opening-ProfessionsPage

### DIFF
--- a/frontend-react/app/layout.tsx
+++ b/frontend-react/app/layout.tsx
@@ -3,6 +3,7 @@ import { Montserrat } from 'next/font/google'
 import { modals } from '@/modals/modals'
 import { ModalProvider } from '@/context/ContextModal'
 import '../styles/globals.css'
+import ScrollRestoration from '@/lib/scroll-restoration'
 
 const montserrat = Montserrat({
     subsets: ['latin'],
@@ -23,6 +24,7 @@ export default function RootLayout({
     return (
         <html lang="en">
             <body className={montserrat.className}>
+                <ScrollRestoration />
                 <ModalProvider modals={modals}>{children}</ModalProvider>
             </body>
         </html>

--- a/frontend-react/lib/scroll-restoration.tsx
+++ b/frontend-react/lib/scroll-restoration.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+export default function ScrollRestoration() {
+    const pathname = usePathname()
+
+    useEffect(() => {
+        if (document.scrollingElement) {
+            document.scrollingElement.scrollTo(0, 0)
+        }
+    }, [pathname])
+
+    return null
+}


### PR DESCRIPTION
Обнаружена ошибка в  Next.js при использовании компонента Link. Cохраняется позиция скролла при переходе между страницами, и после клика на Link  новая страница загружается с сохранённой прокруткой, хотя скролл должен по умолчанию поднимать страницу наверх. Ошибка была в браузерах сафари, хром и файрфокс.

Добавила функцию ScrollRestoration() для обнуление позиции скролла при переходе на новую страницу.
Google Chrome
https://github.com/user-attachments/assets/da14fa06-ce6f-4a85-b797-ab85959ace93
Safari
https://github.com/user-attachments/assets/91ec3ce7-d255-4a0a-ac1d-41e60e77c8c8


