### PR TITLE
FF-106-fix-scrollX-ProfessionModalDesktop fix: handle the change in size

### DIFF
--- a/frontend-react/components/desktop/layout/ProfessionModalDesktop/InternshipCompaniesModalDesktop.tsx
+++ b/frontend-react/components/desktop/layout/ProfessionModalDesktop/InternshipCompaniesModalDesktop.tsx
@@ -30,8 +30,10 @@ const InternshipCompaniesModalDesktop: React.FC = () => {
 
     useEffect(() => {
         const handleResize = () => {
-            const calculatedScrollbarWidth = calculateScrollbarWidth()
-            setScrollbarWidth(calculatedScrollbarWidth)
+            if (contentRef.current && scrollbarRef.current) {
+                const calculatedScrollbarWidth = calculateScrollbarWidth()
+                setScrollbarWidth(calculatedScrollbarWidth)
+            }
         }
 
         window.addEventListener('resize', handleResize)

--- a/frontend-react/components/desktop/layout/ProfessionModalDesktop/InternshipCompaniesModalDesktop.tsx
+++ b/frontend-react/components/desktop/layout/ProfessionModalDesktop/InternshipCompaniesModalDesktop.tsx
@@ -1,12 +1,20 @@
 'use client'
 
-import React, { useRef } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import { contentInternshipCompaniesDesktop } from './content'
 import ItemCompaniesDesktop from './ItemCompaniesDesktop'
 
 const InternshipCompaniesModalDesktop: React.FC = () => {
     const contentRef = useRef<HTMLDivElement>(null)
     const scrollbarRef = useRef<HTMLDivElement>(null)
+    const [scrollbarWidth, setScrollbarWidth] = useState(0)
+
+    const calculateScrollbarWidth = () => {
+        if (!contentRef.current || !scrollbarRef.current) return 0
+        const visibleContentWidth = contentRef.current.offsetWidth
+        const visibleScrollBarWidth = scrollbarRef.current.offsetWidth
+        return contentRef.current.scrollWidth - (visibleContentWidth - visibleScrollBarWidth)
+    }
 
     const handleScroll = () => {
         if (contentRef.current && scrollbarRef.current) {
@@ -20,12 +28,20 @@ const InternshipCompaniesModalDesktop: React.FC = () => {
         }
     }
 
-    const calculateScrollbarWidth = () => {
-        if (!contentRef.current || !scrollbarRef.current) return 0
-        const visibleContentWidth = contentRef.current.offsetWidth
-        const visibleScrollBarWidth = scrollbarRef.current.offsetWidth
-        return contentRef.current.scrollWidth - (visibleContentWidth - visibleScrollBarWidth)
-    }
+    useEffect(() => {
+        const handleResize = () => {
+            const calculatedScrollbarWidth = calculateScrollbarWidth()
+            setScrollbarWidth(calculatedScrollbarWidth)
+        }
+
+        window.addEventListener('resize', handleResize)
+
+        handleResize()
+
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    }, [])
 
     return (
         <>
@@ -48,7 +64,7 @@ const InternshipCompaniesModalDesktop: React.FC = () => {
                 onScroll={handleScrollbarScroll}
                 className="scrollbar_custom relative mx-auto mt-[clamp(25px,_2vw,_40px)] h-2 w-[65%] cursor-pointer overflow-x-scroll"
             >
-                <div className="h-full" style={{ width: `${calculateScrollbarWidth()}px` }}></div>
+                <div className="h-full" style={{ width: `${scrollbarWidth}px` }}></div>
             </div>
         </>
     )

--- a/frontend-react/components/desktop/layout/ProfessionModalDesktop/ProfessionModalDesktop.tsx
+++ b/frontend-react/components/desktop/layout/ProfessionModalDesktop/ProfessionModalDesktop.tsx
@@ -19,12 +19,14 @@ const ProfessionModalDesktop: React.FC<ProfessionModalDesktopProps> = ({ onClose
 
     const handleResize = () => {
         if (contentRef.current) {
-            setContentWidth(contentRef.current.offsetHeight)
+            setContentWidth(contentRef.current.offsetWidth)
         }
     }
 
     useEffect(() => {
-        handleResize()
+        if (contentRef.current) {
+            handleResize()
+        }
         window.addEventListener('resize', handleResize)
 
         return () => {

--- a/frontend-react/components/desktop/layout/ProfessionModalDesktop/ProfessionModalDesktop.tsx
+++ b/frontend-react/components/desktop/layout/ProfessionModalDesktop/ProfessionModalDesktop.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useRef, useState, useEffect } from 'react'
+import React from 'react'
 import { X } from 'lucide-react'
 import Modal from '@/components/ui/modal'
 import { contentProfessionAboutDesktop } from './content'
@@ -14,29 +14,9 @@ interface ProfessionModalDesktopProps {
 }
 
 const ProfessionModalDesktop: React.FC<ProfessionModalDesktopProps> = ({ onClose, profession }) => {
-    const contentRef = useRef<HTMLDivElement>(null)
-    const [contentWidth, setContentWidth] = useState(0)
-
-    const handleResize = () => {
-        if (contentRef.current) {
-            setContentWidth(contentRef.current.offsetWidth)
-        }
-    }
-
-    useEffect(() => {
-        if (contentRef.current) {
-            handleResize()
-        }
-        window.addEventListener('resize', handleResize)
-
-        return () => {
-            window.removeEventListener('resize', handleResize)
-        }
-    }, [])
-
     return (
         <Modal onClose={onClose} size="large-l" showCloseButton={false} className="px-[clamp(180px,_14vw,_277px)]">
-            <div ref={contentRef} className="modal-padding-content-lg-dsk flex flex-col">
+            <div className="modal-padding-content-lg-dsk flex flex-col">
                 <button onClick={onClose} className="absolute right-[36px] top-[23px]">
                     <X size={41} className="color-[#878797] opacity-50 hover:opacity-80"></X>
                 </button>

--- a/frontend-react/components/desktop/layout/ProfessionModalDesktop/ProfessionModalDesktop.tsx
+++ b/frontend-react/components/desktop/layout/ProfessionModalDesktop/ProfessionModalDesktop.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import { X } from 'lucide-react'
 import Modal from '@/components/ui/modal'
 import { contentProfessionAboutDesktop } from './content'
@@ -14,9 +14,27 @@ interface ProfessionModalDesktopProps {
 }
 
 const ProfessionModalDesktop: React.FC<ProfessionModalDesktopProps> = ({ onClose, profession }) => {
+    const contentRef = useRef<HTMLDivElement>(null)
+    const [contentWidth, setContentWidth] = useState(0)
+
+    const handleResize = () => {
+        if (contentRef.current) {
+            setContentWidth(contentRef.current.offsetHeight)
+        }
+    }
+
+    useEffect(() => {
+        handleResize()
+        window.addEventListener('resize', handleResize)
+
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    }, [])
+
     return (
         <Modal onClose={onClose} size="large-l" showCloseButton={false} className="px-[clamp(180px,_14vw,_277px)]">
-            <div className="modal-padding-content-lg-dsk flex flex-col">
+            <div ref={contentRef} className="modal-padding-content-lg-dsk flex flex-col">
                 <button onClick={onClose} className="absolute right-[36px] top-[23px]">
                     <X size={41} className="color-[#878797] opacity-50 hover:opacity-80"></X>
                 </button>

--- a/frontend-react/components/desktop/layout/ProfessionModalDesktop/ReviewsModalDesktop.tsx
+++ b/frontend-react/components/desktop/layout/ProfessionModalDesktop/ReviewsModalDesktop.tsx
@@ -1,12 +1,20 @@
 'use client'
 
-import React, { useRef } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import { contentReviewsDesktop } from './content'
 import ItemReviewsDesktop from './ItemReviewsDesktop'
 
 const ReviewsModalDesktop: React.FC = () => {
     const contentRef = useRef<HTMLDivElement>(null)
     const scrollbarRef = useRef<HTMLDivElement>(null)
+    const [scrollbarWidth, setScrollbarWidth] = useState(0)
+
+    const calculateScrollbarWidth = () => {
+        if (!contentRef.current || !scrollbarRef.current) return 0
+        const visibleContentWidth = contentRef.current.offsetWidth
+        const visibleScrollBarWidth = scrollbarRef.current.offsetWidth
+        return contentRef.current.scrollWidth - (visibleContentWidth - visibleScrollBarWidth)
+    }
 
     const handleScroll = () => {
         if (contentRef.current && scrollbarRef.current) {
@@ -20,12 +28,20 @@ const ReviewsModalDesktop: React.FC = () => {
         }
     }
 
-    const calculateScrollbarWidth = () => {
-        if (!contentRef.current || !scrollbarRef.current) return 0
-        const visibleContentWidth = contentRef.current.offsetWidth
-        const visibleScrollBarWidth = scrollbarRef.current.offsetWidth
-        return contentRef.current.scrollWidth - (visibleContentWidth - visibleScrollBarWidth)
-    }
+    useEffect(() => {
+        const handleResize = () => {
+            const calculatedScrollbarWidth = calculateScrollbarWidth()
+            setScrollbarWidth(calculatedScrollbarWidth)
+        }
+
+        window.addEventListener('resize', handleResize)
+
+        handleResize()
+
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    }, [])
 
     return (
         <div>
@@ -48,7 +64,7 @@ const ReviewsModalDesktop: React.FC = () => {
                 onScroll={handleScrollbarScroll}
                 className="scrollbar_custom relative mx-auto mt-[clamp(25px,_2vw,_40px)] h-[14px] w-[65%] cursor-pointer overflow-x-scroll"
             >
-                <div className="absolute h-2" style={{ width: `${calculateScrollbarWidth()}px` }}></div>
+                <div className="absolute h-2" style={{ width: `${scrollbarWidth}px` }}></div>
             </div>
         </div>
     )

--- a/frontend-react/components/desktop/layout/ProfessionModalDesktop/ReviewsModalDesktop.tsx
+++ b/frontend-react/components/desktop/layout/ProfessionModalDesktop/ReviewsModalDesktop.tsx
@@ -30,8 +30,10 @@ const ReviewsModalDesktop: React.FC = () => {
 
     useEffect(() => {
         const handleResize = () => {
-            const calculatedScrollbarWidth = calculateScrollbarWidth()
-            setScrollbarWidth(calculatedScrollbarWidth)
+            if (contentRef.current && scrollbarRef.current) {
+                const calculatedScrollbarWidth = calculateScrollbarWidth()
+                setScrollbarWidth(calculatedScrollbarWidth)
+            }
         }
 
         window.addEventListener('resize', handleResize)

--- a/frontend-react/components/ui/modal.tsx
+++ b/frontend-react/components/ui/modal.tsx
@@ -54,7 +54,7 @@ const Modal: React.FC<ModalProps> = ({
             role="button"
             tabIndex={0}
             onKeyDown={(e) => {
-                if (e.key === 'Eneter' || e.key === ' ') {
+                if (e.key === 'Enter' || e.key === ' ') {
                     onClose()
                 }
             }}


### PR DESCRIPTION
Сделала scroll активным. Добавила useRef для отслеживания размеров контейнера, useState для сохранения ширины, useEffect для отслеживания изменений размера окна и обновления.
![scroll-fixed](https://github.com/user-attachments/assets/02a69739-33b6-44c9-bca2-ac5e20ce6a76)
