### PR TITLE
ff-111-fix/deleted translate currency in HeaderCards, changed styles in cards Mobi

### DIFF
--- a/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardItemDesktop.tsx
+++ b/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardItemDesktop.tsx
@@ -12,6 +12,7 @@ interface IHeaderCardItem {
     currency: string
     time: string
     tooltipMessage: string
+    disableCurrencyTranslation?: boolean
 }
 
 const HeaderCardItemDesktop: React.FC<IHeaderCardItem> = ({
@@ -22,6 +23,7 @@ const HeaderCardItemDesktop: React.FC<IHeaderCardItem> = ({
     currency,
     time,
     tooltipMessage,
+    disableCurrencyTranslation = true,
 }) => {
     return (
         <>
@@ -52,7 +54,8 @@ const HeaderCardItemDesktop: React.FC<IHeaderCardItem> = ({
                     >
                         от{' '}
                         <span className="text32px_desktop font-medium">
-                            {price} {currency}/ {time}
+                            {price} <span translate={disableCurrencyTranslation ? 'no' : 'yes'}>{currency}</span> /{' '}
+                            {time}
                         </span>
                     </div>
                     <Button

--- a/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardsDesktop.tsx
+++ b/frontend-react/components/desktop/layout/HeaderDesktop/HeaderCardsDesktop.tsx
@@ -15,6 +15,7 @@ const HeaderCardsDesktop: React.FC = () => {
                     currency="BYN"
                     time="неделя"
                     tooltipMessage="Вы получаете стажировку наблюдателя, но с рабочими задачами под ваш уровень и человеком, который в случае чего поможет подтянуть знания"
+                    disableCurrencyTranslation={true}
                 />
                 <HeaderCardItemDesktop
                     textBlack="Стажировка"
@@ -24,6 +25,7 @@ const HeaderCardsDesktop: React.FC = () => {
                     currency="BYN"
                     time="неделя"
                     tooltipMessage="На стажировке вас ждет ментор, обзорные экскурсии и рабочее место, без необходимости работать"
+                    disableCurrencyTranslation={true}
                 />
             </div>
         </>

--- a/frontend-react/components/mobi/layout/HeaderMobi/HeaderCardsItemMobi.tsx
+++ b/frontend-react/components/mobi/layout/HeaderMobi/HeaderCardsItemMobi.tsx
@@ -12,6 +12,7 @@ interface IHeaderCardItem {
     price: number
     currency: string
     tooltipMessage: string
+    disableCurrencyTranslation?: boolean
 }
 
 const HeaderCardsItemMobi: React.FC<IHeaderCardItem> = ({
@@ -21,6 +22,7 @@ const HeaderCardsItemMobi: React.FC<IHeaderCardItem> = ({
     price,
     currency,
     tooltipMessage,
+    disableCurrencyTranslation = true,
 }) => {
     return (
         <>
@@ -34,16 +36,18 @@ const HeaderCardsItemMobi: React.FC<IHeaderCardItem> = ({
                 }}
             >
                 <HelpTooltipMobi tooltipMessage={tooltipMessage} />
-                <div className="relative flex flex-1 flex-col items-center justify-center gap-[17px]">
-                    <div className="sm_s:text-3xl sm_s:leading-[24px] px-[30px] text-justify text-5xl font-medium leading-[32px] text-white sm:text-3xl sm:leading-[24px]">
-                        {textBlack}{' '}
-                        <span className="bg-sub-title-gradient-mobi20 rounded-[20px] px-[4px] font-bold text-white sm:px-[2px]">
-                            {textColor}
-                        </span>{' '}
-                        {textBlackBr}
-                    </div>
-                    <div className="text28px_mobi font-medium text-white">
-                        {price} {currency}
+                <div className="relative flex h-full w-full flex-col items-center justify-center gap-[17px] pb-8">
+                    <div className="flex flex-col items-center justify-center text-center">
+                        <div className="sm_s:text-3xl sm_s:leading-[24px] px-[30px] text-justify text-5xl font-medium leading-[32px] text-white sm:text-3xl sm:leading-[24px]">
+                            {textBlack}{' '}
+                            <span className="bg-sub-title-gradient-mobi20 rounded-[20px] px-[4px] font-bold text-white sm:px-[2px]">
+                                {textColor}
+                            </span>{' '}
+                            {textBlackBr}
+                        </div>
+                        <div className="text28px_mobi font-medium text-white">
+                            {price} <span translate={disableCurrencyTranslation ? 'no' : 'yes'}>{currency}</span>
+                        </div>
                     </div>
                     <Button variant="circleBlue" size="circleMobi" className="absolute bottom-0 right-0">
                         <ArrowWhiteMobi />

--- a/frontend-react/components/mobi/layout/HeaderMobi/HeaderCardsMobi.tsx
+++ b/frontend-react/components/mobi/layout/HeaderMobi/HeaderCardsMobi.tsx
@@ -14,6 +14,7 @@ const HeaderCardsMobi: React.FC = () => {
                     price={123}
                     currency="BYN"
                     tooltipMessage="Вы получаете стажировку наблюдателя, но с рабочими задачами под ваш уровень и человеком, который в случае чего поможет подтянуть знания"
+                    disableCurrencyTranslation={true}
                 />
                 <HeaderCardsItemMobi
                     textBlack="Стажировка"
@@ -22,6 +23,7 @@ const HeaderCardsMobi: React.FC = () => {
                     price={123}
                     currency="BYN"
                     tooltipMessage="На стажировке вас ждет ментор, обзорные экскурсии и рабочее место, без необходимости работать"
+                    disableCurrencyTranslation={true}
                 />
             </div>
         </>


### PR DESCRIPTION
Удален автоматический перевод валюты в карточках HeaderCardsDesktop и HeaderCardsMobi на главной странице. 
В карточках HeaderCardsMobi настроено вертикальное центрирование контента. 

![0](https://github.com/user-attachments/assets/ebf4debd-f701-4b32-b4e3-31e382ebbb24)
![1](https://github.com/user-attachments/assets/7680d8b9-98d4-4a78-9de5-2ee4eaee5774)
