### PR TITLE
FF-136 Привести стиль пагинации на странице "Мероприятия" в соответствие с макетом.

### DIFF
--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsPaginationDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsPaginationDesktop.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { LessIcon, MoreIcon } from '@/components/assets/icons'
+import { LessIconDesktop, MoreIconDesktop } from '@/components/assets/icons'
 
 interface IProfessionsPagination {
     totalPages: number
@@ -42,8 +42,14 @@ const EventsPaginationDesktop: React.FC<IProfessionsPagination> = ({ totalPages,
 
     return (
         <div className="relative z-[2] mb-[88px] mt-[73px] flex items-center justify-center gap-5">
-            <button onClick={() => onPageChange(Math.max(1, currentPage - 1))} disabled={currentPage === 1}>
-                <LessIcon />
+            <button
+                onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+                disabled={currentPage === 1}
+                className={`transition-colors duration-300 ${
+                    currentPage === 1 ? 'cursor-not-allowed text-[#878797]' : 'cursor-pointer text-[#FFFFFFCC]'
+                }`}
+            >
+                <LessIconDesktop />
             </button>
 
             <div className="flex items-end justify-center gap-5">
@@ -56,9 +62,7 @@ const EventsPaginationDesktop: React.FC<IProfessionsPagination> = ({ totalPages,
                         <button
                             key={`page-${page}`}
                             className={`text-7xl font-medium ${
-                                currentPage === page
-                                    ? 'text-gradient_desktop_custom border-b-2 border-indigo-500 text-[32px]'
-                                    : 'text-[FFFFCC]'
+                                currentPage === page ? 'text-gradient_desktop_custom' : 'text-[#FFFFFFCC]'
                             }`}
                             onClick={() => onPageChange(page)}
                         >
@@ -71,8 +75,11 @@ const EventsPaginationDesktop: React.FC<IProfessionsPagination> = ({ totalPages,
             <button
                 onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
                 disabled={currentPage === totalPages}
+                className={`transition-colors duration-300 ${
+                    currentPage >= totalPages ? 'cursor-not-allowed text-[#878797]' : 'cursor-pointer text-[#FFFFFFCC]'
+                }`}
             >
-                <MoreIcon />
+                <MoreIconDesktop />
             </button>
         </div>
     )


### PR DESCRIPTION
Изменения только для стилей, логика осталась нетронутой:

- Иконки с LessIcon на LessIconDesktop
- Стиль стрелок, когда на первой странице, меняет курсор и не дает использовать стрелку назад. Когда на последней также блокирует и задает серый цвет стрелке вперед.
- Стиль цифр
- Опечатку text-[FFFFCC] на text-[#FFFFCC]

![Screenshot_2025-04-15_06-08-56](https://github.com/user-attachments/assets/7203526b-7abd-4bde-a73b-4ab1160319da)


