### PR TITLE
ff-144-fix/deleted onWidthChange, corrected scroll on desktop

### DIFF
--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/EventsSectionDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/EventsSectionDesktop.tsx
@@ -1,25 +1,50 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import TitleDesktop from '@/components/desktop/shared/TitleDesktop'
 import ItemEventsDesktop from './ItemEventsDesktop/ItemEventsDesktop'
 import { contentEventsSection } from './contentEventsSectionDesktop/content'
+
 const EventsSectionDesktop: React.FC = () => {
     const contentRef = useRef<HTMLDivElement>(null)
     const scrollbarRef = useRef<HTMLDivElement>(null)
-    const [itemWidth, setItemWidth] = useState<number>(0)
+    const [contentWidth, setContentWidth] = useState<number>(0)
+    const [visibleWidth, setVisibleWidth] = useState<number>(0)
+
+    useEffect(() => {
+        const updateSizes = () => {
+            if (contentRef.current) {
+                setContentWidth(contentRef.current.scrollWidth)
+                setVisibleWidth(contentRef.current.clientWidth)
+            }
+        }
+
+        updateSizes()
+        window.addEventListener('resize', updateSizes)
+
+        return () => {
+            window.removeEventListener('resize', updateSizes)
+        }
+    }, [contentEventsSection])
 
     const handleScroll = () => {
         if (contentRef.current && scrollbarRef.current) {
-            scrollbarRef.current.scrollLeft = contentRef.current.scrollLeft
+            const scrollRatio =
+                contentRef.current.scrollLeft / (contentRef.current.scrollWidth - contentRef.current.clientWidth)
+            const scrollbarScrollLeft =
+                scrollRatio * (scrollbarRef.current.scrollWidth - scrollbarRef.current.clientWidth)
+            scrollbarRef.current.scrollLeft = scrollbarScrollLeft
         }
     }
 
     const handleScrollbarScroll = () => {
         if (contentRef.current && scrollbarRef.current) {
-            contentRef.current.scrollLeft = scrollbarRef.current.scrollLeft
+            const scrollRatio =
+                scrollbarRef.current.scrollLeft / (scrollbarRef.current.scrollWidth - scrollbarRef.current.clientWidth)
+            const contentScrollLeft = scrollRatio * (contentRef.current.scrollWidth - contentRef.current.clientWidth)
+            contentRef.current.scrollLeft = contentScrollLeft
         }
     }
 
-    const scrollbarWidth = `${((contentEventsSection.length * itemWidth) / window.innerWidth) * 150}%`
+    const scrollbarWidth = contentWidth > visibleWidth ? `${(contentWidth / visibleWidth) * 100}%` : '100%'
 
     return (
         <div className="py-[10vh]">
@@ -32,13 +57,7 @@ const EventsSectionDesktop: React.FC = () => {
                 className="no-scrollbar_custom container mt-[6vh] flex select-none gap-8 overflow-x-scroll"
             >
                 {contentEventsSection.map((item) => (
-                    <ItemEventsDesktop
-                        image={item.image}
-                        title={item.title}
-                        date={item.date}
-                        key={item.id}
-                        onWidthChange={setItemWidth}
-                    />
+                    <ItemEventsDesktop image={item.image} title={item.title} date={item.date} key={item.id} />
                 ))}
             </div>
             <div
@@ -51,4 +70,5 @@ const EventsSectionDesktop: React.FC = () => {
         </div>
     )
 }
+
 export default EventsSectionDesktop

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
@@ -1,26 +1,19 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef } from 'react'
 import Image from 'next/image'
 
 interface IEventSection {
     image: string
     title: string
     date: string
-    onWidthChange: (width: number) => void
 }
 
-const ItemEventsDesktop: React.FC<IEventSection> = ({ image, title, date, onWidthChange }) => {
+const ItemEventsDesktop: React.FC<IEventSection> = ({ image, title, date }) => {
     const [day, month] = date.split(' ')
 
     const itemRef = useRef<HTMLDivElement>(null)
 
-    useEffect(() => {
-        if (itemRef.current) {
-            onWidthChange(itemRef.current.offsetWidth)
-        }
-    }, [onWidthChange])
-
     return (
-        <div ref={itemRef} className=" flex min-w-[27%] max-w-[27%] flex-col pt-[4vh]">
+        <div ref={itemRef} className="flex min-w-[27%] max-w-[27%] flex-col pt-[4vh]">
             <div className="hover:button-shadow_around_desktop_custom relative aspect-[4/3] w-full cursor-pointer rounded-[3.125rem]">
                 <Image
                     src={image}
@@ -32,7 +25,7 @@ const ItemEventsDesktop: React.FC<IEventSection> = ({ image, title, date, onWidt
                     <p className="4xl:text-7xl 3xl:text-6xl text-9xl font-semibold text-[#1f203f] 2xl:text-4xl">
                         {day}
                     </p>
-                    <p className="4xl:text-2xl 3xl:text-xl text-4xl  font-medium text-[#878797] 2xl:text-lg">{month}</p>
+                    <p className="4xl:text-2xl 3xl:text-xl text-4xl font-medium text-[#878797] 2xl:text-lg">{month}</p>
                 </div>
             </div>
             <p className="4xl:text-7xl 3xl:text-6xl line-clamp-2 max-h-[calc(2*2.5rem)] overflow-hidden text-ellipsis pt-5 text-9xl font-medium uppercase leading-[1.2] text-white 2xl:text-4xl">
@@ -41,4 +34,5 @@ const ItemEventsDesktop: React.FC<IEventSection> = ({ image, title, date, onWidt
         </div>
     )
 }
+
 export default ItemEventsDesktop


### PR DESCRIPTION
Откорректирован скролл на главной странице в разделе Мероприятия для Десктопа.

>1920
![1921](https://github.com/user-attachments/assets/b287f67d-afd1-4f6c-9df9-a46774134a14)

4xl
![4xl](https://github.com/user-attachments/assets/6282ba8d-c1e2-44ed-bc29-b0c5ff479182)

3xl
![3xl](https://github.com/user-attachments/assets/4a442fa5-392e-404a-aa3c-42f5f2bca2fb)

2xl
![2xl](https://github.com/user-attachments/assets/74f1339d-2a40-4856-81c3-85e095ca3bb8)
