### PR TITLE
FF-204-feat/events-filters-desktop

### DIFF
--- a/frontend-react/components/assets/iconsDesktop.tsx
+++ b/frontend-react/components/assets/iconsDesktop.tsx
@@ -676,3 +676,19 @@ export const MapPinIconDesktop: React.FC<SVGProps<SVGSVGElement>> = (props) => {
         </svg>
     )
 }
+
+export const CloseIconDesktop: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+    return (
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+            <path
+                d="M1 1L11 11M11 1L1 11"
+                stroke="white"
+                strokeOpacity="0.5"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    )
+}
+

--- a/frontend-react/components/assets/iconsDesktop.tsx
+++ b/frontend-react/components/assets/iconsDesktop.tsx
@@ -691,4 +691,3 @@ export const CloseIconDesktop: React.FC<SVGProps<SVGSVGElement>> = (props) => {
         </svg>
     )
 }
-

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -53,9 +53,9 @@ const EventsPageDesktop: React.FC = () => {
                 <div className="3xl:p-[76px_130px_150px_130px] container relative min-h-screen overflow-hidden p-[76px_212px_200px_212px] 2xl:p-[60px_100px_100px_100px]">
                     <h1 className="title80px_desktop relative z-[1]">Мероприятия</h1>
                     <div className="relative z-[1] flex items-center justify-end gap-[30px] pb-[30px] pt-[116px]">
-                        <EventsSelectSearchDesktop />
+                        <EventsSelectSearchDesktop selected={selectedCategories} onChange={setSelectedCategories} />
                         <EventsSelectSearchDateDesktop dates={dates} setDates={setDates} />
-                        <EventsSelectSearchCityDesktop />
+                        <EventsSelectSearchCityDesktop selected={selectedCities} onChange={setSelectedCities} />
                     </div>
                     <div className="3xl:gap-[25px] 4xl:gap-[30px] flex min-h-[40vh] flex-wrap justify-center gap-[36px] 2xl:gap-[20px]">
                         {!isEmpty ? (

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -21,6 +21,8 @@ const EventsPageDesktop: React.FC = () => {
     const [currentPage, setCurrentPage] = useState(1)
     const [filteredContent, setFilteredContent] = useState(content)
     const [dates, setDates] = useState<{ from: Date | null; to: Date | null }>({ from: null, to: null })
+    const [selectedCategories, setSelectedCategories] = useState<string[]>([])
+    const [selectedCities, setSelectedCities] = useState<string[]>([])
 
     useEffect(() => {
         const { from, to } = dates

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -8,6 +8,8 @@ import EventsPaginationDesktop from './components/EventsPaginationDesktop'
 import EventsSelectSearchDesktop from './components/EventsSelectSearchDesktop'
 import EventsSelectSearchDateDesktop from './components/EventsSelectSearchDateDesktop'
 import EventsSelectSearchCityDesktop from './components/EventsSelectSearchCityDesktop'
+import { CloseIconDesktop } from '@/components/assets/iconsDesktop'
+import { Button } from '@/components/ui/button'
 import { content } from './contentEventsPageDesktop/content'
 
 const parseDate = (dateStr: string): Date => {
@@ -107,69 +109,65 @@ const EventsPageDesktop: React.FC = () => {
                 <div className="container relative min-h-screen overflow-hidden p-[76px_212px_200px_212px] 2xl:p-[60px_100px_100px_100px] 3xl:p-[76px_130px_150px_130px]">
                     <h1 className="title80px_desktop relative z-[1]">Мероприятия</h1>
 
-                    <div className="relative z-[1] flex items-center justify-end gap-[30px] pt-[116px] pb-[30px]">
+                    <div className="relative z-[1] flex items-center justify-end gap-[30px] pt-[116px]">
                         <EventsSelectSearchDesktop selected={selectedCategories} onChange={setSelectedCategories} />
                         <EventsSelectSearchDateDesktop dates={dates} setDates={setDates} />
                         <EventsSelectSearchCityDesktop selected={selectedCities} onChange={setSelectedCities} />
                     </div>
 
-                    <div className="mt-6 flex flex-wrap items-center gap-3">
-                        {selectedCategories.map((slug) => (
-                            <div
-                                key={slug}
-                                className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white"
-                            >
-                                {categoryLabelBySlug[slug]}
-                                <button
-                                    onClick={() => setSelectedCategories((prev) => prev.filter((s) => s !== slug))}
-                                    className="ml-2"
+                    {selectedCategories.length > 0 || selectedCities.length > 0 || dates.from || dates.to ? (
+                        <div className="flex flex-wrap items-center gap-x-[32px] gap-y-[16px] mt-[39px] mb-[30px]">
+                            {selectedCategories.map((slug) => (
+                                <div
+                                    key={slug}
+                                    className="flex items-center rounded-full bg-[#ffffff1a] py-[16px] pl-[45px] pr-[45px] text-white"
                                 >
-                                    ✕
-                                </button>
-                            </div>
-                        ))}
+                                    <span className="font-semibold text-[20px]">{categoryLabelBySlug[slug]}</span>
+                                    <button
+                                        onClick={() => setSelectedCategories((prev) => prev.filter((s) => s !== slug))}
+                                        className="ml-[40px] flex items-center justify-center"
+                                    >
+                                        <CloseIconDesktop className="h-3 w-3" />
+                                    </button>
+                                </div>
+                            ))}
 
-                        {(dates.from || dates.to) && (
-                            <div className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white">
-                                {dates.from && dates.to
-                                    ? `${dates.from.toLocaleDateString('ru-RU')} — ${dates.to.toLocaleDateString('ru-RU')}`
-                                    : dates.from
-                                    ? `С ${dates.from.toLocaleDateString('ru-RU')}`
-                                    : `До ${dates.to?.toLocaleDateString('ru-RU')}`}
-                                <button onClick={() => setDates({ from: null, to: null })} className="ml-2">
-                                    ✕
-                                </button>
-                            </div>
-                        )}
+                            {(dates.from || dates.to) && (
+                                <div className="flex items-center rounded-full bg-[#ffffff1a] py-[16px] pl-[45px] pr-[45px] text-white">
+                                    <span className="font-semibold text-[20px]">
+                                        {dates.from && dates.to
+                                            ? `${dates.from.toLocaleDateString('ru-RU')} — ${dates.to.toLocaleDateString('ru-RU')}`
+                                            : dates.from
+                                              ? `С ${dates.from.toLocaleDateString('ru-RU')}`
+                                              : `До ${dates.to?.toLocaleDateString('ru-RU')}`}
+                                    </span>
+                                    <button
+                                        onClick={() => setDates({ from: null, to: null })}
+                                        className="ml-[40px] flex items-center justify-center"
+                                    >
+                                        <CloseIconDesktop className="h-3 w-3" />
+                                    </button>
+                                </div>
+                            )}
 
-                        {selectedCities.map((slug) => (
-                            <div
-                                key={slug}
-                                className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white"
-                            >
-                                {cityLabelBySlug[slug]}
-                                <button
-                                    onClick={() => setSelectedCities((prev) => prev.filter((s) => s !== slug))}
-                                    className="ml-2"
+                            {selectedCities.map((slug) => (
+                                <div
+                                    key={slug}
+                                    className="flex items-center rounded-full bg-[#ffffff1a] py-[16px] pl-[45px] pr-[45px] text-white"
                                 >
-                                    ✕
-                                </button>
-                            </div>
-                        ))}
-
-                        {(selectedCategories.length > 0 || selectedCities.length > 0 || dates.from || dates.to) && (
-                            <button
-                                onClick={() => {
-                                    setSelectedCategories([])
-                                    setSelectedCities([])
-                                    setDates({ from: null, to: null })
-                                }}
-                                className="ml-4 rounded-[18px] border-2 border-[#878797] px-4 py-2 text-[#FFFFFFCC] hover:border-white hover:text-white"
-                            >
-                                Сбросить фильтры
-                            </button>
-                        )}
-                    </div>
+                                    <span className="font-semibold text-[20px]">{cityLabelBySlug[slug]}</span>
+                                    <button
+                                        onClick={() => setSelectedCities((prev) => prev.filter((s) => s !== slug))}
+                                        className="ml-[40px] flex items-center justify-center"
+                                    >
+                                        <CloseIconDesktop className="h-3 w-3" />
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="mt-[30px]" />
+                    )}
 
                     <div className="flex min-h-[40vh] flex-wrap justify-center gap-[36px] 2xl:gap-[20px] 3xl:gap-[25px] 4xl:gap-[30px]">
                         {!isEmpty ? (
@@ -188,7 +186,29 @@ const EventsPageDesktop: React.FC = () => {
                                 />
                             ))
                         ) : (
-                            <p className="pt-10 text-4xl opacity-20">Нет мероприятий по данным фильтрам</p>
+                            <div className="flex flex-col items-center justify-center pt-113 text-center">
+                                <p className="text-[24px] font-medium leading-[40px] text-[#353652] mb-[24px] text-center">
+                                    Нет мероприятий по данным категориям
+                                </p>
+
+                                {(selectedCategories.length > 0 ||
+                                    selectedCities.length > 0 ||
+                                    dates.from ||
+                                    dates.to) && (
+                                    <Button
+                                        variant="select_btn_desktop"
+                                        size="select_btn_desktop_events"
+                                        onClick={() => {
+                                            setSelectedCategories([])
+                                            setSelectedCities([])
+                                            setDates({ from: null, to: null })
+                                        }}
+                                        className="px-[35px]"
+                                    >
+                                        Сбросить фильтры
+                                    </Button>
+                                )}
+                            </div>
                         )}
                     </div>
 

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -20,44 +20,110 @@ const cardsPerPage = 6
 const EventsPageDesktop: React.FC = () => {
     const [currentPage, setCurrentPage] = useState(1)
     const [filteredContent, setFilteredContent] = useState(content)
-    const [dates, setDates] = useState<{ from: Date | null; to: Date | null }>({ from: null, to: null })
+
+    const [dates, setDates] = useState<{ from: Date | null; to: Date | null }>({
+        from: null,
+        to: null,
+    })
     const [selectedCategories, setSelectedCategories] = useState<string[]>([])
     const [selectedCities, setSelectedCities] = useState<string[]>([])
 
     useEffect(() => {
         const { from, to } = dates
-        const filtered = content.filter((item) => {
-            const itemDate = parseDate(item.date)
-            if (from && to) return itemDate >= from && itemDate <= to
-            if (from) return itemDate >= from
-            if (to) return itemDate <= to
-            return true
-        })
+        const result = content
+            .filter((item) => {
+                const itemDate = parseDate(item.date)
+                if (from && itemDate < from) return false
+                if (to && itemDate > to) return false
+                return true
+            })
+            .filter((item) => (selectedCategories.length === 0 ? true : selectedCategories.includes(item.category)))
+            .filter((item) => (selectedCities.length === 0 ? true : selectedCities.includes(item.city)))
 
-        setFilteredContent(filtered)
+        setFilteredContent(result)
         setCurrentPage(1)
-    }, [dates])
+    }, [dates, selectedCategories, selectedCities])
 
     const isEmpty = filteredContent.length === 0
     const totalPages = Math.ceil(filteredContent.length / cardsPerPage)
     const paginatedCards = filteredContent.slice((currentPage - 1) * cardsPerPage, currentPage * cardsPerPage)
-
-    const handlePageChange = (page: number): void => {
+    const handlePageChange = (page: number) => {
         setCurrentPage(page)
     }
 
     return (
         <>
             <HeaderDesktop />
+
             <main className="bg-[#101030] text-white">
-                <div className="3xl:p-[76px_130px_150px_130px] container relative min-h-screen overflow-hidden p-[76px_212px_200px_212px] 2xl:p-[60px_100px_100px_100px]">
+                <div className="container relative min-h-screen overflow-hidden p-[76px_212px_200px_212px] 2xl:p-[60px_100px_100px_100px] 3xl:p-[76px_130px_150px_130px]">
                     <h1 className="title80px_desktop relative z-[1]">Мероприятия</h1>
-                    <div className="relative z-[1] flex items-center justify-end gap-[30px] pb-[30px] pt-[116px]">
+
+                    <div className="relative z-[1] flex items-center justify-end gap-[30px] pt-[116px] pb-[30px]">
                         <EventsSelectSearchDesktop selected={selectedCategories} onChange={setSelectedCategories} />
                         <EventsSelectSearchDateDesktop dates={dates} setDates={setDates} />
                         <EventsSelectSearchCityDesktop selected={selectedCities} onChange={setSelectedCities} />
                     </div>
-                    <div className="3xl:gap-[25px] 4xl:gap-[30px] flex min-h-[40vh] flex-wrap justify-center gap-[36px] 2xl:gap-[20px]">
+
+                    <div className="mt-6 flex flex-wrap items-center gap-3">
+                        {selectedCategories.map((cat) => (
+                            <div
+                                key={cat}
+                                className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white"
+                            >
+                                {cat}
+                                <button
+                                    onClick={() => setSelectedCategories((prev) => prev.filter((x) => x !== cat))}
+                                    className="ml-2"
+                                >
+                                    ✕
+                                </button>
+                            </div>
+                        ))}
+
+                        {(dates.from || dates.to) && (
+                            <div className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white">
+                                {dates.from && dates.to
+                                    ? `${dates.from.toLocaleDateString('ru-RU')} — ${dates.to.toLocaleDateString('ru-RU')}`
+                                    : dates.from
+                                    ? `С ${dates.from.toLocaleDateString('ru-RU')}`
+                                    : `До ${dates.to?.toLocaleDateString('ru-RU')}`}
+                                <button onClick={() => setDates({ from: null, to: null })} className="ml-2">
+                                    ✕
+                                </button>
+                            </div>
+                        )}
+
+                        {selectedCities.map((city) => (
+                            <div
+                                key={city}
+                                className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white"
+                            >
+                                {city}
+                                <button
+                                    onClick={() => setSelectedCities((prev) => prev.filter((x) => x !== city))}
+                                    className="ml-2"
+                                >
+                                    ✕
+                                </button>
+                            </div>
+                        ))}
+
+                        {(selectedCategories.length > 0 || selectedCities.length > 0 || dates.from || dates.to) && (
+                            <button
+                                onClick={() => {
+                                    setSelectedCategories([])
+                                    setSelectedCities([])
+                                    setDates({ from: null, to: null })
+                                }}
+                                className="ml-4 rounded-[18px] border-2 border-[#878797] px-4 py-2 text-[#FFFFFFCC] hover:border-white hover:text-white"
+                            >
+                                Сбросить фильтры
+                            </button>
+                        )}
+                    </div>
+
+                    <div className="flex min-h-[40vh] flex-wrap justify-center gap-[36px] 2xl:gap-[20px] 3xl:gap-[25px] 4xl:gap-[30px]">
                         {!isEmpty ? (
                             paginatedCards.map((item) => (
                                 <EventsCardDesktop
@@ -74,11 +140,10 @@ const EventsPageDesktop: React.FC = () => {
                                 />
                             ))
                         ) : (
-                            <div>
-                                <p className="pt-10 text-4xl opacity-20">Нет мероприятий по данным категориям</p>
-                            </div>
+                            <p className="pt-10 text-4xl opacity-20">Нет мероприятий по данным фильтрам</p>
                         )}
                     </div>
+
                     {totalPages > 1 && (
                         <EventsPaginationDesktop
                             totalPages={totalPages}
@@ -88,6 +153,7 @@ const EventsPageDesktop: React.FC = () => {
                     )}
                 </div>
             </main>
+
             <FooterDesktop />
         </>
     )

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -82,7 +82,7 @@ const EventsPageDesktop: React.FC = () => {
 
         setFilteredContent(result)
         setCurrentPage(1)
-    }, [dates, selectedCategories, selectedCity]) 
+    }, [dates, selectedCategories, selectedCity])
 
     const isEmpty = filteredContent.length === 0
     const totalPages = Math.ceil(filteredContent.length / cardsPerPage)
@@ -130,7 +130,7 @@ const EventsPageDesktop: React.FC = () => {
                                         className="px-[30px]"
                                         onClick={() => {
                                             setSelectedCategories([])
-                                            setSelectedCity(null) 
+                                            setSelectedCity(null)
                                             setDates({ from: null, to: null })
                                         }}
                                     >

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -17,6 +17,49 @@ const parseDate = (dateStr: string): Date => {
 
 const cardsPerPage = 6
 
+interface ISelectOption {
+    value: string
+    label: string
+}
+
+const categoryOptions: ISelectOption[] = [
+    { value: 'fairs', label: 'Выставки/презентации' },
+    { value: 'open_days', label: 'Дни открытых дверей' },
+    { value: 'conferences', label: 'Конференции' },
+    { value: 'master_classes', label: 'Мастер‑классы/семинары/тренинги' },
+    { value: 'internships', label: 'Стажировки' },
+    { value: 'job_fairs', label: 'Ярмарки вакансий' },
+]
+
+const cityOptions: ISelectOption[] = [
+    { value: 'minsk', label: 'Минск' },
+    { value: 'brest', label: 'Брест' },
+    { value: 'vitebsk', label: 'Витебск' },
+    { value: 'gomel', label: 'Гомель' },
+    { value: 'grodno', label: 'Гродно' },
+    { value: 'mogilev', label: 'Могилев' },
+]
+
+const categoryValueBySlug: Record<string, string> = {
+    fairs: 'выставка',
+    open_days: 'дни открытых дверей',
+    conferences: 'конференции',
+    master_classes: 'мастер‑классы/семинары/тренинги',
+    internships: 'стажировки',
+    job_fairs: 'ярмарки вакансий',
+}
+const cityValueBySlug: Record<string, string> = {
+    minsk: 'Минск',
+    brest: 'Брест',
+    vitebsk: 'Витебск',
+    gomel: 'Гомель',
+    grodno: 'Гродно',
+    mogilev: 'Могилев',
+}
+
+const categoryLabelBySlug: Record<string, string> = Object.fromEntries(categoryOptions.map((o) => [o.value, o.label]))
+const cityLabelBySlug: Record<string, string> = Object.fromEntries(cityOptions.map((o) => [o.value, o.label]))
+
 const EventsPageDesktop: React.FC = () => {
     const [currentPage, setCurrentPage] = useState(1)
     const [filteredContent, setFilteredContent] = useState(content)
@@ -30,15 +73,22 @@ const EventsPageDesktop: React.FC = () => {
 
     useEffect(() => {
         const { from, to } = dates
+
         const result = content
             .filter((item) => {
-                const itemDate = parseDate(item.date)
-                if (from && itemDate < from) return false
-                if (to && itemDate > to) return false
+                const d = parseDate(item.date)
+                if (from && d < from) return false
+                if (to && d > to) return false
                 return true
             })
-            .filter((item) => (selectedCategories.length === 0 ? true : selectedCategories.includes(item.category)))
-            .filter((item) => (selectedCities.length === 0 ? true : selectedCities.includes(item.city)))
+            .filter((item) =>
+                selectedCategories.length === 0
+                    ? true
+                    : selectedCategories.some((slug) => categoryValueBySlug[slug] === item.category),
+            )
+            .filter((item) =>
+                selectedCities.length === 0 ? true : selectedCities.some((slug) => cityValueBySlug[slug] === item.city),
+            )
 
         setFilteredContent(result)
         setCurrentPage(1)
@@ -46,15 +96,13 @@ const EventsPageDesktop: React.FC = () => {
 
     const isEmpty = filteredContent.length === 0
     const totalPages = Math.ceil(filteredContent.length / cardsPerPage)
-    const paginatedCards = filteredContent.slice((currentPage - 1) * cardsPerPage, currentPage * cardsPerPage)
-    const handlePageChange = (page: number) => {
-        setCurrentPage(page)
-    }
+    const paginated = filteredContent.slice((currentPage - 1) * cardsPerPage, currentPage * cardsPerPage)
+
+    const handlePageChange = (page: number) => setCurrentPage(page)
 
     return (
         <>
             <HeaderDesktop />
-
             <main className="bg-[#101030] text-white">
                 <div className="container relative min-h-screen overflow-hidden p-[76px_212px_200px_212px] 2xl:p-[60px_100px_100px_100px] 3xl:p-[76px_130px_150px_130px]">
                     <h1 className="title80px_desktop relative z-[1]">Мероприятия</h1>
@@ -66,14 +114,14 @@ const EventsPageDesktop: React.FC = () => {
                     </div>
 
                     <div className="mt-6 flex flex-wrap items-center gap-3">
-                        {selectedCategories.map((cat) => (
+                        {selectedCategories.map((slug) => (
                             <div
-                                key={cat}
+                                key={slug}
                                 className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white"
                             >
-                                {cat}
+                                {categoryLabelBySlug[slug]}
                                 <button
-                                    onClick={() => setSelectedCategories((prev) => prev.filter((x) => x !== cat))}
+                                    onClick={() => setSelectedCategories((prev) => prev.filter((s) => s !== slug))}
                                     className="ml-2"
                                 >
                                     ✕
@@ -94,14 +142,14 @@ const EventsPageDesktop: React.FC = () => {
                             </div>
                         )}
 
-                        {selectedCities.map((city) => (
+                        {selectedCities.map((slug) => (
                             <div
-                                key={city}
+                                key={slug}
                                 className="flex items-center rounded-full bg-gradient-to-r from-[#8333F3] via-[#5F4AF3] to-[#3B51A8] px-4 py-2 text-white"
                             >
-                                {city}
+                                {cityLabelBySlug[slug]}
                                 <button
-                                    onClick={() => setSelectedCities((prev) => prev.filter((x) => x !== city))}
+                                    onClick={() => setSelectedCities((prev) => prev.filter((s) => s !== slug))}
                                     className="ml-2"
                                 >
                                     ✕
@@ -125,7 +173,7 @@ const EventsPageDesktop: React.FC = () => {
 
                     <div className="flex min-h-[40vh] flex-wrap justify-center gap-[36px] 2xl:gap-[20px] 3xl:gap-[25px] 4xl:gap-[30px]">
                         {!isEmpty ? (
-                            paginatedCards.map((item) => (
+                            paginated.map((item) => (
                                 <EventsCardDesktop
                                     key={item.id}
                                     title={item.title}

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -8,7 +8,7 @@ import EventsPaginationDesktop from './components/EventsPaginationDesktop'
 import EventsSelectSearchDesktop from './components/EventsSelectSearchDesktop'
 import EventsSelectSearchDateDesktop from './components/EventsSelectSearchDateDesktop'
 import EventsSelectSearchCityDesktop from './components/EventsSelectSearchCityDesktop'
-import { CloseIconDesktop } from '@/components/assets/iconsDesktop'
+import EventsSelectedFiltersDesktop from './components/EventsSelectedFiltersDesktop'
 import { Button } from '@/components/ui/button'
 import { content } from './contentEventsPageDesktop/content'
 
@@ -19,29 +19,6 @@ const parseDate = (dateStr: string): Date => {
 
 const cardsPerPage = 6
 
-interface ISelectOption {
-    value: string
-    label: string
-}
-
-const categoryOptions: ISelectOption[] = [
-    { value: 'fairs', label: 'Выставки/презентации' },
-    { value: 'open_days', label: 'Дни открытых дверей' },
-    { value: 'conferences', label: 'Конференции' },
-    { value: 'master_classes', label: 'Мастер‑классы/семинары/тренинги' },
-    { value: 'internships', label: 'Стажировки' },
-    { value: 'job_fairs', label: 'Ярмарки вакансий' },
-]
-
-const cityOptions: ISelectOption[] = [
-    { value: 'minsk', label: 'Минск' },
-    { value: 'brest', label: 'Брест' },
-    { value: 'vitebsk', label: 'Витебск' },
-    { value: 'gomel', label: 'Гомель' },
-    { value: 'grodno', label: 'Гродно' },
-    { value: 'mogilev', label: 'Могилев' },
-]
-
 const categoryValueBySlug: Record<string, string> = {
     fairs: 'выставка',
     open_days: 'дни открытых дверей',
@@ -50,6 +27,16 @@ const categoryValueBySlug: Record<string, string> = {
     internships: 'стажировки',
     job_fairs: 'ярмарки вакансий',
 }
+
+const categoryLabelBySlug: Record<string, string> = {
+    fairs: 'Выставки/презентации',
+    open_days: 'Дни открытых дверей',
+    conferences: 'Конференции',
+    master_classes: 'Мастер‑классы/семинары/тренинги',
+    internships: 'Стажировки',
+    job_fairs: 'Ярмарки вакансий',
+}
+
 const cityValueBySlug: Record<string, string> = {
     minsk: 'Минск',
     brest: 'Брест',
@@ -59,19 +46,22 @@ const cityValueBySlug: Record<string, string> = {
     mogilev: 'Могилев',
 }
 
-const categoryLabelBySlug: Record<string, string> = Object.fromEntries(categoryOptions.map((o) => [o.value, o.label]))
-const cityLabelBySlug: Record<string, string> = Object.fromEntries(cityOptions.map((o) => [o.value, o.label]))
+const cityLabelBySlug: Record<string, string> = {
+    minsk: 'Минск',
+    brest: 'Брест',
+    vitebsk: 'Витебск',
+    gomel: 'Гомель',
+    grodno: 'Гродно',
+    mogilev: 'Могилев',
+}
 
 const EventsPageDesktop: React.FC = () => {
     const [currentPage, setCurrentPage] = useState(1)
     const [filteredContent, setFilteredContent] = useState(content)
 
-    const [dates, setDates] = useState<{ from: Date | null; to: Date | null }>({
-        from: null,
-        to: null,
-    })
+    const [dates, setDates] = useState<{ from: Date | null; to: Date | null }>({ from: null, to: null })
     const [selectedCategories, setSelectedCategories] = useState<string[]>([])
-    const [selectedCities, setSelectedCities] = useState<string[]>([])
+    const [selectedCity, setSelectedCity] = useState<string | null>(null)
 
     useEffect(() => {
         const { from, to } = dates
@@ -88,13 +78,11 @@ const EventsPageDesktop: React.FC = () => {
                     ? true
                     : selectedCategories.some((slug) => categoryValueBySlug[slug] === item.category),
             )
-            .filter((item) =>
-                selectedCities.length === 0 ? true : selectedCities.some((slug) => cityValueBySlug[slug] === item.city),
-            )
+            .filter((item) => (!selectedCity ? true : cityValueBySlug[selectedCity] === item.city))
 
         setFilteredContent(result)
         setCurrentPage(1)
-    }, [dates, selectedCategories, selectedCities])
+    }, [dates, selectedCategories, selectedCity]) 
 
     const isEmpty = filteredContent.length === 0
     const totalPages = Math.ceil(filteredContent.length / cardsPerPage)
@@ -105,6 +93,7 @@ const EventsPageDesktop: React.FC = () => {
     return (
         <>
             <HeaderDesktop />
+
             <main className="bg-[#101030] text-white">
                 <div className="container relative min-h-screen overflow-hidden p-[76px_212px_200px_212px] 2xl:p-[60px_100px_100px_100px] 3xl:p-[76px_130px_150px_130px]">
                     <h1 className="title80px_desktop relative z-[1]">Мероприятия</h1>
@@ -112,98 +101,38 @@ const EventsPageDesktop: React.FC = () => {
                     <div className="relative z-[1] flex items-center justify-end gap-[30px] pt-[116px]">
                         <EventsSelectSearchDesktop selected={selectedCategories} onChange={setSelectedCategories} />
                         <EventsSelectSearchDateDesktop dates={dates} setDates={setDates} />
-                        <EventsSelectSearchCityDesktop selected={selectedCities} onChange={setSelectedCities} />
+                        <EventsSelectSearchCityDesktop selected={selectedCity} onChange={setSelectedCity} />
                     </div>
 
-                    {selectedCategories.length > 0 || selectedCities.length > 0 || dates.from || dates.to ? (
-                        <div className="flex flex-wrap items-center gap-x-[32px] gap-y-[16px] mt-[39px] mb-[30px]">
-                            {selectedCategories.map((slug) => (
-                                <div
-                                    key={slug}
-                                    className="flex items-center rounded-full bg-[#ffffff1a] py-[16px] pl-[45px] pr-[45px] text-white"
-                                >
-                                    <span className="font-semibold text-[20px]">{categoryLabelBySlug[slug]}</span>
-                                    <button
-                                        onClick={() => setSelectedCategories((prev) => prev.filter((s) => s !== slug))}
-                                        className="ml-[40px] flex items-center justify-center"
-                                    >
-                                        <CloseIconDesktop className="h-3 w-3" />
-                                    </button>
-                                </div>
-                            ))}
+                    <EventsSelectedFiltersDesktop
+                        selectedCategories={selectedCategories}
+                        setSelectedCategories={setSelectedCategories}
+                        dates={dates}
+                        setDates={setDates}
+                        selectedCity={selectedCity}
+                        setSelectedCity={setSelectedCity}
+                        categoryLabelBySlug={categoryLabelBySlug}
+                        cityLabelBySlug={cityLabelBySlug}
+                    />
 
-                            {(dates.from || dates.to) && (
-                                <div className="flex items-center rounded-full bg-[#ffffff1a] py-[16px] pl-[45px] pr-[45px] text-white">
-                                    <span className="font-semibold text-[20px]">
-                                        {dates.from && dates.to
-                                            ? `${dates.from.toLocaleDateString('ru-RU')} — ${dates.to.toLocaleDateString('ru-RU')}`
-                                            : dates.from
-                                              ? `С ${dates.from.toLocaleDateString('ru-RU')}`
-                                              : `До ${dates.to?.toLocaleDateString('ru-RU')}`}
-                                    </span>
-                                    <button
-                                        onClick={() => setDates({ from: null, to: null })}
-                                        className="ml-[40px] flex items-center justify-center"
-                                    >
-                                        <CloseIconDesktop className="h-3 w-3" />
-                                    </button>
-                                </div>
-                            )}
-
-                            {selectedCities.map((slug) => (
-                                <div
-                                    key={slug}
-                                    className="flex items-center rounded-full bg-[#ffffff1a] py-[16px] pl-[45px] pr-[45px] text-white"
-                                >
-                                    <span className="font-semibold text-[20px]">{cityLabelBySlug[slug]}</span>
-                                    <button
-                                        onClick={() => setSelectedCities((prev) => prev.filter((s) => s !== slug))}
-                                        className="ml-[40px] flex items-center justify-center"
-                                    >
-                                        <CloseIconDesktop className="h-3 w-3" />
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
-                    ) : (
-                        <div className="mt-[30px]" />
-                    )}
-
-                    <div className="flex min-h-[40vh] flex-wrap justify-center gap-[36px] 2xl:gap-[20px] 3xl:gap-[25px] 4xl:gap-[30px]">
+                    <div className="flex min-h-[40vh] flex-wrap justify-center gap-9 2xl:gap-5 3xl:gap-[25px] 4xl:gap-[30px]">
                         {!isEmpty ? (
-                            paginated.map((item) => (
-                                <EventsCardDesktop
-                                    key={item.id}
-                                    title={item.title}
-                                    category={item.category}
-                                    image={item.image}
-                                    date={item.date}
-                                    time={item.time}
-                                    week={item.week}
-                                    city={item.city}
-                                    place={item.place}
-                                    company={item.company}
-                                />
-                            ))
+                            paginated.map((item) => <EventsCardDesktop key={item.id} {...item} />)
                         ) : (
-                            <div className="flex flex-col items-center justify-center pt-113 text-center">
-                                <p className="text-[24px] font-medium leading-[40px] text-[#353652] mb-[24px] text-center">
-                                    Нет мероприятий по данным категориям
+                            <div className="flex flex-col items-center justify-center pt-[113px] text-center">
+                                <p className="text-7xl font-medium leading-10 text-[#353652] mb-6 text-center">
+                                    Нет мероприятий по данным фильтрам
                                 </p>
-
-                                {(selectedCategories.length > 0 ||
-                                    selectedCities.length > 0 ||
-                                    dates.from ||
-                                    dates.to) && (
+                                {(selectedCategories.length > 0 || selectedCity || dates.from || dates.to) && (
                                     <Button
                                         variant="select_btn_desktop"
                                         size="select_btn_desktop_events"
+                                        className="px-[30px]"
                                         onClick={() => {
                                             setSelectedCategories([])
-                                            setSelectedCities([])
+                                            setSelectedCity(null) 
                                             setDates({ from: null, to: null })
                                         }}
-                                        className="px-[35px]"
                                     >
                                         Сбросить фильтры
                                     </Button>

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
@@ -54,8 +54,7 @@ const EventsSelectSearchCityDesktop: React.FC<Props> = ({ selected, onChange }) 
 
             {isOpen && (
                 <div
-                    className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px]"
-                    style={{ background: 'linear-gradient(90deg, #8333f3, #5f4af3, #3b51a8)' }}
+                    className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px] bg-gradient-desktop"
                 >
                     <div className="flex flex-col gap-1 rounded-[42px] bg-[#1F203F] p-3">
                         <div className="border-white-300 flex items-center rounded-[50px] border px-3">

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
@@ -4,61 +4,46 @@ import React, { useState, useRef, useEffect } from 'react'
 import { ChevronDownIconDesktop, SearchIconDesktop } from '@/components/assets/iconsDesktop'
 import { Button } from '@/components/ui/button'
 
-interface EventsSelectSearchCityDesktopProps {
-    selected: string[]
-    onChange: (newSelected: string[]) => void
+interface Props {
+    selected: string | null
+    onChange: (city: string | null) => void
 }
 
-interface ISelectOption {
-    value: string
-    label: string
-}
+const options = [
+    { value: 'brest', label: 'Брест' },
+    { value: 'vitebsk', label: 'Витебск' },
+    { value: 'gomel', label: 'Гомель' },
+    { value: 'grodno', label: 'Гродно' },
+    { value: 'mogilev', label: 'Могилев' },
+    { value: 'minsk', label: 'Минск' },
+]
 
-const EventsSelectSearchCityDesktop: React.FC<EventsSelectSearchCityDesktopProps> = ({ selected, onChange }) => {
+const EventsSelectSearchCityDesktop: React.FC<Props> = ({ selected, onChange }) => {
     const [isOpen, setIsOpen] = useState(false)
     const [searchTerm, setSearchTerm] = useState('')
-    const dropdownRef = useRef<HTMLDivElement>(null)
-
-    const handleSelectToggle = () => {
-        setIsOpen((prev) => !prev)
-    }
+    const ref = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) {
                 setIsOpen(false)
             }
         }
         document.addEventListener('mousedown', handleClickOutside)
-        return () => {
-            document.removeEventListener('mousedown', handleClickOutside)
-        }
+        return () => document.removeEventListener('mousedown', handleClickOutside)
     }, [])
 
-    const options: ISelectOption[] = [
-        { value: 'brest', label: 'Брест' },
-        { value: 'vitebsk', label: 'Витебск' },
-        { value: 'gomel', label: 'Гомель' },
-        { value: 'grodno', label: 'Гродно' },
-        { value: 'mogilev', label: 'Могилев' },
-        { value: 'minsk', label: 'Минск' },
-    ]
-
-    const filteredOptions = options.filter((opt) => opt.label.toLowerCase().includes(searchTerm.toLowerCase()))
-
-    const toggleOption = (value: string) => {
-        const next = selected.includes(value) ? selected.filter((opt) => opt !== value) : [...selected, value]
-        onChange(next)
-    }
+    const filtered = options.filter((o) => o.label.toLowerCase().includes(searchTerm.toLowerCase()))
 
     return (
-        <div className="relative z-[3]" ref={dropdownRef}>
+        <div className="relative z-[3]" ref={ref}>
             <Button
                 variant="select_btn_desktop"
                 size="select_btn_desktop_date"
-                onClick={handleSelectToggle}
-                className={`${isOpen ? 'bg-gradient-desktop' : 'bg-[#101030]'}`}
+                onClick={() => setIsOpen((v) => !v)}
+                className={isOpen ? 'bg-gradient-desktop' : 'bg-[#101030]'}
             >
+                {/* Всегда показываем заглушку «Город» */}
                 Город
                 <ChevronDownIconDesktop
                     className={`h-[15px] w-[27px] transition-transform duration-200 2xl:w-[20px] ${
@@ -70,9 +55,7 @@ const EventsSelectSearchCityDesktop: React.FC<EventsSelectSearchCityDesktopProps
             {isOpen && (
                 <div
                     className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px]"
-                    style={{
-                        background: 'linear-gradient(90deg, #8333f3, #5f4af3, #3b51a8)',
-                    }}
+                    style={{ background: 'linear-gradient(90deg, #8333f3, #5f4af3, #3b51a8)' }}
                 >
                     <div className="flex flex-col gap-1 rounded-[42px] bg-[#1F203F] p-3">
                         <div className="border-white-300 flex items-center rounded-[50px] border px-3">
@@ -81,23 +64,34 @@ const EventsSelectSearchCityDesktop: React.FC<EventsSelectSearchCityDesktopProps
                                 placeholder="Поиск"
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                className="text-18px flex h-11 w-full rounded-md bg-transparent py-3 outline-none placeholder:text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
+                                className="text-18px flex h-11 w-full rounded-md bg-transparent py-3 outline-none placeholder:text-gray-500"
                             />
-                            <SearchIconDesktop
-                                className="mr-2 size-4 shrink-0 opacity-50"
-                                onClick={() => console.log('Search icon clicked!')}
-                            />
+                            <SearchIconDesktop className="mr-2 size-4 shrink-0 opacity-50" />
                         </div>
-
-                        {filteredOptions.map((option) => (
-                            <SelectItem
-                                key={option.value}
-                                value={option.value}
-                                isChecked={selected.includes(option.value)}
-                                onClick={() => toggleOption(option.value)}
+                        {filtered.map((opt) => (
+                            <div
+                                key={opt.value}
+                                onClick={() => {
+                                    onChange(opt.value)
+                                    setIsOpen(false)
+                                }}
+                                role="menuitem"
+                                tabIndex={0}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault()
+                                        onChange(opt.value)
+                                        setIsOpen(false)
+                                    }
+                                }}
+                                className={`hover:border-hover text-[18px] font-medium relative z-[3] flex cursor-pointer items-center justify-between p-[15px] text-white ${
+                                    selected === opt.value
+                                        ? 'border-selected border-y-2 bg-[#28295B]'
+                                        : 'bg-transparent'
+                                }`}
                             >
-                                {option.label}
-                            </SelectItem>
+                                <div className="pl-[14px]">{opt.label}</div>
+                            </div>
                         ))}
                     </div>
                 </div>
@@ -105,34 +99,5 @@ const EventsSelectSearchCityDesktop: React.FC<EventsSelectSearchCityDesktopProps
         </div>
     )
 }
-
-interface ISelectItemProps {
-    value: string
-    children: React.ReactNode
-    isChecked: boolean
-    onClick: () => void
-}
-
-const SelectItem = React.forwardRef<HTMLDivElement, ISelectItemProps>(({ children, isChecked, onClick }, ref) => (
-    <div
-        ref={ref}
-        onClick={onClick}
-        role="menuitem"
-        tabIndex={0}
-        onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                onClick()
-            }
-        }}
-        className={`hover:border-hover text-[18px] font-medium relative z-[3] flex cursor-pointer items-center justify-between p-[15px] text-white ${
-            isChecked ? 'border-selected border-y-2 bg-[#28295B]' : 'bg-transparent'
-        }`}
-    >
-        <div className="pl-[14px]">{children}</div>
-    </div>
-))
-
-SelectItem.displayName = 'SelectItem'
 
 export default EventsSelectSearchCityDesktop

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
@@ -36,12 +36,12 @@ const EventsSelectSearchCityDesktop: React.FC<EventsSelectSearchCityDesktopProps
     }, [])
 
     const options: ISelectOption[] = [
-        { value: 'brest', label: 'Брест' },
-        { value: 'vitebsk', label: 'Витебск' },
-        { value: 'gomel', label: 'Гомель' },
-        { value: 'grodno', label: 'Гродно' },
-        { value: 'mogilev', label: 'Могилев' },
-        { value: 'minsk', label: 'Минск' },
+        { value: 'Брест', label: 'Брест' },
+        { value: 'Витебск', label: 'Витебск' },
+        { value: 'Гомель', label: 'Гомель' },
+        { value: 'Гродно', label: 'Гродно' },
+        { value: 'Могилев', label: 'Могилев' },
+        { value: 'Минск', label: 'Минск' },
     ]
 
     const filteredOptions = options.filter((opt) => opt.label.toLowerCase().includes(searchTerm.toLowerCase()))

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
@@ -36,12 +36,12 @@ const EventsSelectSearchCityDesktop: React.FC<EventsSelectSearchCityDesktopProps
     }, [])
 
     const options: ISelectOption[] = [
-        { value: 'Брест', label: 'Брест' },
-        { value: 'Витебск', label: 'Витебск' },
-        { value: 'Гомель', label: 'Гомель' },
-        { value: 'Гродно', label: 'Гродно' },
-        { value: 'Могилев', label: 'Могилев' },
-        { value: 'Минск', label: 'Минск' },
+        { value: 'brest', label: 'Брест' },
+        { value: 'vitebsk', label: 'Витебск' },
+        { value: 'gomel', label: 'Гомель' },
+        { value: 'grodno', label: 'Гродно' },
+        { value: 'mogilev', label: 'Могилев' },
+        { value: 'minsk', label: 'Минск' },
     ]
 
     const filteredOptions = options.filter((opt) => opt.label.toLowerCase().includes(searchTerm.toLowerCase()))

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
@@ -43,7 +43,6 @@ const EventsSelectSearchCityDesktop: React.FC<Props> = ({ selected, onChange }) 
                 onClick={() => setIsOpen((v) => !v)}
                 className={isOpen ? 'bg-gradient-desktop' : 'bg-[#101030]'}
             >
-                {/* Всегда показываем заглушку «Город» */}
                 Город
                 <ChevronDownIconDesktop
                     className={`h-[15px] w-[27px] transition-transform duration-200 2xl:w-[20px] ${

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchCityDesktop.tsx
@@ -3,11 +3,10 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { ChevronDownIconDesktop, SearchIconDesktop } from '@/components/assets/iconsDesktop'
 import { Button } from '@/components/ui/button'
-interface ISelectItem {
-    value: string
-    children: React.ReactNode
-    isChecked: boolean
-    onClick: () => void
+
+interface EventsSelectSearchCityDesktopProps {
+    selected: string[]
+    onChange: (newSelected: string[]) => void
 }
 
 interface ISelectOption {
@@ -15,17 +14,10 @@ interface ISelectOption {
     label: string
 }
 
-const EventsSelectSearchCityDesktop = () => {
+const EventsSelectSearchCityDesktop: React.FC<EventsSelectSearchCityDesktopProps> = ({ selected, onChange }) => {
     const [isOpen, setIsOpen] = useState(false)
-    const [selectedOptions, setSelectedOptions] = useState<string[]>([])
     const [searchTerm, setSearchTerm] = useState('')
     const dropdownRef = useRef<HTMLDivElement>(null)
-
-    const toggleOption = (value: string) => {
-        setSelectedOptions((prev) =>
-            prev.includes(value) ? prev.filter((option) => option !== value) : [...prev, value],
-        )
-    }
 
     const handleSelectToggle = () => {
         setIsOpen((prev) => !prev)
@@ -52,21 +44,29 @@ const EventsSelectSearchCityDesktop = () => {
         { value: 'minsk', label: 'Минск' },
     ]
 
-    const filteredOptions = options.filter((option) => option.label.toLowerCase().includes(searchTerm.toLowerCase()))
+    const filteredOptions = options.filter((opt) => opt.label.toLowerCase().includes(searchTerm.toLowerCase()))
+
+    const toggleOption = (value: string) => {
+        const next = selected.includes(value) ? selected.filter((opt) => opt !== value) : [...selected, value]
+        onChange(next)
+    }
 
     return (
         <div className="relative z-[3]" ref={dropdownRef}>
             <Button
-                variant={'select_btn_desktop'}
-                size={'select_btn_desktop_date'}
+                variant="select_btn_desktop"
+                size="select_btn_desktop_date"
                 onClick={handleSelectToggle}
-                className={` ${isOpen ? ' bg-gradient-desktop' : 'bg-[#101030]'}`}
+                className={`${isOpen ? 'bg-gradient-desktop' : 'bg-[#101030]'}`}
             >
                 Город
                 <ChevronDownIconDesktop
-                    className={`h-[15px] w-[27px] transition-transform  duration-200 2xl:w-[20px] ${isOpen ? 'rotate-180' : ''}`}
+                    className={`h-[15px] w-[27px] transition-transform duration-200 2xl:w-[20px] ${
+                        isOpen ? 'rotate-180' : ''
+                    }`}
                 />
             </Button>
+
             {isOpen && (
                 <div
                     className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px]"
@@ -88,11 +88,12 @@ const EventsSelectSearchCityDesktop = () => {
                                 onClick={() => console.log('Search icon clicked!')}
                             />
                         </div>
+
                         {filteredOptions.map((option) => (
                             <SelectItem
                                 key={option.value}
                                 value={option.value}
-                                isChecked={selectedOptions.includes(option.value)}
+                                isChecked={selected.includes(option.value)}
                                 onClick={() => toggleOption(option.value)}
                             >
                                 {option.label}
@@ -105,32 +106,32 @@ const EventsSelectSearchCityDesktop = () => {
     )
 }
 
-const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem>(
-    ({ children, isChecked, onClick, ...props }, forwardedRef) => {
-        return (
-            <div
-                className={`hover:border-hover text-[18px]font-medium relative z-[3] flex cursor-pointer items-center justify-between p-[15px] text-white ${
-                    isChecked ? 'border-selected border-y-2 bg-[#28295B]' : 'bg-transparent'
-                }`}
-                {...props}
-                ref={forwardedRef}
-                onClick={onClick}
-                role="menuitem"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        onClick()
-                    }
-                }}
-            >
-                <div className="flex ">
-                    <div className="pl-[14px]">{children}</div>
-                </div>
-            </div>
-        )
-    },
-)
+interface ISelectItemProps {
+    value: string
+    children: React.ReactNode
+    isChecked: boolean
+    onClick: () => void
+}
+
+const SelectItem = React.forwardRef<HTMLDivElement, ISelectItemProps>(({ children, isChecked, onClick }, ref) => (
+    <div
+        ref={ref}
+        onClick={onClick}
+        role="menuitem"
+        tabIndex={0}
+        onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onClick()
+            }
+        }}
+        className={`hover:border-hover text-[18px] font-medium relative z-[3] flex cursor-pointer items-center justify-between p-[15px] text-white ${
+            isChecked ? 'border-selected border-y-2 bg-[#28295B]' : 'bg-transparent'
+        }`}
+    >
+        <div className="pl-[14px]">{children}</div>
+    </div>
+))
 
 SelectItem.displayName = 'SelectItem'
 

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDateDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDateDesktop.tsx
@@ -171,10 +171,7 @@ const EventsSelectSearchDateDesktop: React.FC<EventsSelectSearchDateDesktopProps
 
             {isOpen && (
                 <div
-                    className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[430px] rounded-[42px] p-[2px] 2xl:w-[270px]"
-                    style={{
-                        background: 'linear-gradient(90deg, #8333f3, #5f4af3, #3b51a8)',
-                    }}
+                    className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[430px] rounded-[42px] p-[2px] 2xl:w-[270px] bg-gradient-desktop"
                 >
                     <div className="relative flex flex-col gap-1 rounded-[42px] bg-[#1F203F] p-3">
                         <div className="custom-grey flex items-center justify-between">

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDateDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDateDesktop.tsx
@@ -6,8 +6,6 @@ import {
     ChevronDownIconDesktop,
     LineDateDesktop,
     CalendarIconsDesktop,
-    QuestionMarkDesktop,
-    CheckedBoxIconDesktop,
 } from '@/components/assets/iconsDesktop'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -36,12 +36,12 @@ const EventsSelectSearchDesktop: React.FC<EventsSelectSearchDesktopProps> = ({ s
     }, [])
 
     const options: ISelectOption[] = [
-        { value: 'fairs', label: 'Выставки/презентации' },
-        { value: 'open_days', label: 'Дни открытых дверей' },
-        { value: 'conferences', label: 'Конференции' },
-        { value: 'master_classes', label: 'Мастер-классы/семинары/тренинги' },
-        { value: 'internships', label: 'Стажировки' },
-        { value: 'job_fairs', label: 'Ярмарки вакансий' },
+        { value: 'Выставки/презентации', label: 'Выставки/презентации' },
+        { value: 'Дни открытых дверей', label: 'Дни открытых дверей' },
+        { value: 'Конференции', label: 'Конференции' },
+        { value: 'Мастер‑классы/семинары/тренинги', label: 'Мастер‑классы/семинары/тренинги' },
+        { value: 'Стажировки', label: 'Стажировки' },
+        { value: 'Ярмарки вакансий', label: 'Ярмарки вакансий' },
     ]
 
     const toggleOption = (value: string) => {

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -4,11 +4,9 @@ import React, { useEffect, useRef, useState } from 'react'
 import { ChevronDownIconDesktop, CheckedBoxIconDesktop, QuestionMarkDesktop } from '@/components/assets/iconsDesktop'
 import { Button } from '@/components/ui/button'
 
-interface ISelectItem {
-    value: string
-    children: React.ReactNode
-    isChecked: boolean
-    onClick: () => void
+interface EventsSelectSearchDesktopProps {
+    selected: string[]
+    onChange: (newSelected: string[]) => void
 }
 
 interface ISelectOption {
@@ -16,16 +14,9 @@ interface ISelectOption {
     label: string
 }
 
-const EventsSelectSearchDesktop = () => {
+const EventsSelectSearchDesktop: React.FC<EventsSelectSearchDesktopProps> = ({ selected, onChange }) => {
     const [isOpen, setIsOpen] = useState(false)
-    const [selectedOptions, setSelectedOptions] = useState<string[]>([])
     const dropdownRef = useRef<HTMLDivElement>(null)
-
-    const toggleOption = (value: string) => {
-        setSelectedOptions((prev) =>
-            prev.includes(value) ? prev.filter((option) => option !== value) : [...prev, value],
-        )
-    }
 
     const handleSelectToggle = () => {
         setIsOpen((prev) => !prev)
@@ -53,19 +44,27 @@ const EventsSelectSearchDesktop = () => {
         { value: 'job_fairs', label: 'Ярмарки вакансий' },
     ]
 
+    const toggleOption = (value: string) => {
+        const next = selected.includes(value) ? selected.filter((opt) => opt !== value) : [...selected, value]
+        onChange(next)
+    }
+
     return (
         <div className="relative z-[3]" ref={dropdownRef}>
             <Button
-                variant={'select_btn_desktop'}
-                size={'select_btn_desktop_events'}
+                variant="select_btn_desktop"
+                size="select_btn_desktop_events"
                 onClick={handleSelectToggle}
-                className={` ${isOpen ? ' bg-gradient-desktop' : 'bg-[#101030]'}`}
+                className={`${isOpen ? 'bg-gradient-desktop' : 'bg-[#101030]'}`}
             >
                 Мероприятия
                 <ChevronDownIconDesktop
-                    className={`h-[15px] w-[27px] transition-transform  duration-200 2xl:w-[20px] ${isOpen ? 'rotate-180' : ''}`}
+                    className={`h-[15px] w-[27px] transition-transform duration-200 2xl:w-[20px] ${
+                        isOpen ? 'rotate-180' : ''
+                    }`}
                 />
             </Button>
+
             {isOpen && (
                 <div
                     className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px]"
@@ -78,7 +77,7 @@ const EventsSelectSearchDesktop = () => {
                             <SelectItem
                                 key={option.value}
                                 value={option.value}
-                                isChecked={selectedOptions.includes(option.value)}
+                                isChecked={selected.includes(option.value)}
                                 onClick={() => toggleOption(option.value)}
                             >
                                 {option.label}
@@ -91,62 +90,55 @@ const EventsSelectSearchDesktop = () => {
     )
 }
 
-const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem>(
-    ({ children, isChecked, onClick, ...props }, forwardedRef) => {
-        return (
-            <div
-                className={`relative z-[3] flex cursor-pointer items-center justify-between rounded-[18px] p-[15px] text-[15px] font-medium ${
-                    isChecked ? 'bg-[#5F4AF30F] text-white' : 'bg-transparent text-[#878797]'
-                }`}
-                {...props}
-                ref={forwardedRef}
-                onClick={onClick}
-                role="menuitem"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        onClick()
-                    }
-                }}
-            >
-                <div className="flex ">
-                    <div className="relative flex size-[20px] items-center justify-center">
-                        <input
-                            type="checkbox"
-                            checked={isChecked}
-                            onChange={(e) => {
-                                e.stopPropagation()
-                                onClick()
-                            }}
-                            className="absolute inset-0 size-full cursor-pointer opacity-0"
+interface ISelectItemProps {
+    value: string
+    children: React.ReactNode
+    isChecked: boolean
+    onClick: () => void
+}
+
+const SelectItem = React.forwardRef<HTMLDivElement, ISelectItemProps>(
+    ({ children, isChecked, onClick }, forwardedRef) => (
+        <div
+            ref={forwardedRef}
+            onClick={onClick}
+            role="menuitem"
+            tabIndex={0}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    onClick()
+                }
+            }}
+            className={`relative z-[3] flex cursor-pointer items-center justify-between rounded-[18px] p-[15px] text-[15px] font-medium ${
+                isChecked ? 'bg-[#5F4AF30F] text-white' : 'bg-transparent text-[#878797]'
+            }`}
+        >
+            <div className="flex items-center">
+                <div className="relative flex size-[20px] items-center justify-center">
+                    <input
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={(e) => {
+                            e.stopPropagation()
+                            onClick()
+                        }}
+                        className="absolute inset-0 size-full cursor-pointer opacity-0"
+                    />
+                    {isChecked ? (
+                        <CheckedBoxIconDesktop style={{ position: 'absolute', width: '30px', height: '25px' }} />
+                    ) : (
+                        <div
+                            className="absolute inset-0 rounded-[3px]"
+                            style={{ border: '2px solid #878797', background: 'transparent' }}
                         />
-                        {isChecked ? (
-                            <CheckedBoxIconDesktop
-                                style={{
-                                    position: 'absolute',
-                                    width: '30px',
-                                    height: '25px',
-                                }}
-                            />
-                        ) : (
-                            <div
-                                className="absolute inset-0 z-[3] rounded-[3px]"
-                                style={{
-                                    border: '2px solid #878797',
-                                    background: 'transparent',
-                                }}
-                            ></div>
-                        )}
-                    </div>
-                    <div className="pl-[14px]">{children}</div>
+                    )}
                 </div>
-                <div className="justify-items-end">
-                    <QuestionMarkDesktop />
-                </div>
+                <div className="pl-[14px]">{children}</div>
             </div>
-        )
-    },
+            <QuestionMarkDesktop />
+        </div>
+    ),
 )
 
 SelectItem.displayName = 'SelectItem'

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -36,12 +36,12 @@ const EventsSelectSearchDesktop: React.FC<EventsSelectSearchDesktopProps> = ({ s
     }, [])
 
     const options: ISelectOption[] = [
-        { value: 'Выставки/презентации', label: 'Выставки/презентации' },
-        { value: 'Дни открытых дверей', label: 'Дни открытых дверей' },
-        { value: 'Конференции', label: 'Конференции' },
-        { value: 'Мастер‑классы/семинары/тренинги', label: 'Мастер‑классы/семинары/тренинги' },
-        { value: 'Стажировки', label: 'Стажировки' },
-        { value: 'Ярмарки вакансий', label: 'Ярмарки вакансий' },
+        { value: 'fairs', label: 'Выставки/презентации' },
+        { value: 'open_days', label: 'Дни открытых дверей' },
+        { value: 'conferences', label: 'Конференции' },
+        { value: 'master_classes', label: 'Мастер‑классы/семинары/тренинги' },
+        { value: 'internships', label: 'Стажировки' },
+        { value: 'job_fairs', label: 'Ярмарки вакансий' },
     ]
 
     const toggleOption = (value: string) => {

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -67,10 +67,7 @@ const EventsSelectSearchDesktop: React.FC<EventsSelectSearchDesktopProps> = ({ s
 
             {isOpen && (
                 <div
-                    className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px]"
-                    style={{
-                        background: 'linear-gradient(90deg, #8333f3, #5f4af3, #3b51a8)',
-                    }}
+                    className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px] bg-gradient-desktop"
                 >
                     <div className="flex flex-col gap-1 rounded-[42px] bg-[#1F203F] p-3">
                         {options.map((option) => (

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectedFiltersDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectedFiltersDesktop.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import React from 'react'
+import { CloseIconDesktop } from '@/components/assets/iconsDesktop'
+
+interface Props {
+    selectedCategories: string[]
+    setSelectedCategories: (cats: string[]) => void
+    dates: { from: Date | null; to: Date | null }
+    setDates: (d: { from: Date | null; to: Date | null }) => void
+    selectedCity: string | null
+    setSelectedCity: (city: string | null) => void
+    categoryLabelBySlug: Record<string, string>
+    cityLabelBySlug: Record<string, string>
+}
+
+const EventsSelectedFiltersDesktop: React.FC<Props> = ({
+    selectedCategories,
+    setSelectedCategories,
+    dates,
+    setDates,
+    selectedCity,
+    setSelectedCity,
+    categoryLabelBySlug,
+    cityLabelBySlug,
+}) => {
+    const hasAny = selectedCategories.length > 0 || (dates.from !== null && dates.to !== null) || selectedCity !== null
+
+    if (!hasAny) return <div className="mt-[30px]" />
+
+    return (
+        <div className="flex flex-wrap items-center gap-x-8 gap-y-4 mt-[39px] mb-[30px]">
+            {selectedCategories.map((slug) => (
+                <div
+                    key={slug}
+                    className="flex items-center rounded-[50px] bg-[#ffffff1a] py-4 pl-[45px] pr-[45px] text-white"
+                >
+                    <span className="font-semibold text-5xl">{categoryLabelBySlug[slug]}</span>
+                    <button
+                        onClick={() => setSelectedCategories(selectedCategories.filter((s) => s !== slug))}
+                        className="ml-10 flex items-center justify-center"
+                    >
+                        <CloseIconDesktop className="h-3 w-3" />
+                    </button>
+                </div>
+            ))}
+
+            {dates.from && dates.to && (
+                <div className="flex items-center rounded-[50px] bg-[#ffffff1a] py-4 pl-[45px] pr-[45px] text-white">
+                    <span className="font-semibold text-5xl">
+                        {`${dates.from.toLocaleDateString('ru-RU')} — ${dates.to.toLocaleDateString('ru-RU')}`}
+                    </span>
+                    <button
+                        onClick={() => setDates({ from: null, to: null })}
+                        className="ml-10 flex items-center justify-center"
+                    >
+                        <CloseIconDesktop className="h-3 w-3" />
+                    </button>
+                </div>
+            )}
+
+            {selectedCity && (
+                <div className="flex items-center rounded-[50px] bg-[#ffffff1a] py-4 pl-[45px] pr-[45px] text-white">
+                    <span className="font-semibold text-5xl">{cityLabelBySlug[selectedCity]}</span>
+                    <button onClick={() => setSelectedCity(null)} className="ml-10 flex items-center justify-center">
+                        <CloseIconDesktop className="h-3 w-3" />
+                    </button>
+                </div>
+            )}
+        </div>
+    )
+}
+
+export default EventsSelectedFiltersDesktop


### PR DESCRIPTION
- Добавила под селекторами отображение активных фильтров для категорий, городов и диапазона дат.

- Реализовала удаление каждого фильтра по кнопке «×» на бэйдже.

- Добавила кнопку «Сбросить фильтры», очищающую все фильтры одним кликом.

Проверила корректность верстки и работы компонентов на ключевых десктоп‑брейкпоинтах (1024, 1239, 1440, 1560, 1920, >1920 px).

<img width="991" height="599" alt="FF-204-feat-2560" src="https://github.com/user-attachments/assets/c63f82cd-c219-4880-aa1b-819bcf8bb5c9" />
<img width="991" height="599" alt="FF-204-feat-1920" src="https://github.com/user-attachments/assets/e62a7d13-0aaf-49a0-af62-7b0d4dbc47ae" />
<img width="991" height="599" alt="FF-204-feat-1560" src="https://github.com/user-attachments/assets/31236a16-b706-4bc0-bf91-5239abeca43c" />
<img width="991" height="599" alt="FF-204-feat-1440" src="https://github.com/user-attachments/assets/dffb27a2-ed9b-41bb-afbc-c81f5052b8d6" />
<img width="991" height="599" alt="FF-204-feat-1440-2" src="https://github.com/user-attachments/assets/4daccc4d-0184-4888-95ad-ffc91e055e43" />
<img width="991" height="599" alt="FF-204-feat-1239" src="https://github.com/user-attachments/assets/77d2020d-0fe8-4b13-88c9-4b93ef1673fa" />
<img width="991" height="599" alt="FF-204-feat-1024" src="https://github.com/user-attachments/assets/8415ba6d-cb89-44ad-b0b3-8d628d5bed16" />
<img width="991" height="599" alt="FF-204-feat-1024-2" src="https://github.com/user-attachments/assets/45024686-93ce-4152-ace4-8c31cd467645" />
