### PR TITLE
FF-223-feat events info tooltip desktop

### DIFF
--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import React, { useEffect, useRef, useState } from 'react'
-import { ChevronDownIconDesktop, CheckedBoxIconDesktop, QuestionMarkDesktop } from '@/components/assets/iconsDesktop'
-import { categoryOptions } from '../contentEventsPageDesktop/content';
+import { CheckedBoxIconDesktop, ChevronDownIconDesktop, QuestionMarkDesktop } from '@/components/assets/iconsDesktop'
 import { Button } from '@/components/ui/button'
 import { HelpEventsTooltipDesktop } from '@/components/ui/tooltip'
 
@@ -13,20 +12,19 @@ interface ISelectItem {
     onClick: () => void
 }
 
-
 interface ISelectOption {
     value: string
     label: string
     tooltipMessage: string
-
+}
 interface IEventsSelectSearch {
     selectedOptions: string[]
     onChange: (newSelected: string[]) => void
-
 }
 
-const EventsSelectSearchDesktop: React.FC<IEventsSelectSearch> = ({ selectedOptions, onChange }) => {
+const EventsSelectSearchDesktop: React.FC<IEventsSelectSearch> = () => {
     const [isOpen, setIsOpen] = useState(false)
+    const [selectedOptions, setSelectedOptions] = useState<string[]>([])
     const dropdownRef = useRef<HTMLDivElement>(null)
 
     const handleSelectToggle = () => {
@@ -85,13 +83,10 @@ const EventsSelectSearchDesktop: React.FC<IEventsSelectSearch> = ({ selectedOpti
         },
     ]
     const toggleOption = (value: string) => {
-        const next = selectedOptions.includes(value) 
-        ? selectedOptions.filter((opt) => opt !== value) 
-        : [...selectedOptions, value]
-        onChange(next)
+        setSelectedOptions((prev) =>
+            prev.includes(value) ? prev.filter((option) => option !== value) : [...prev, value],
+        )
     }
-
-
     return (
         <div className="relative z-[3]" ref={dropdownRef}>
             <Button
@@ -109,11 +104,9 @@ const EventsSelectSearchDesktop: React.FC<IEventsSelectSearch> = ({ selectedOpti
             </Button>
 
             {isOpen && (
-                <div
-                    className="3xl:w-[300px] absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] p-[2px] 2xl:w-[270px] bg-gradient-desktop"
-                >
+                <div className="absolute right-0 top-[80px] z-50 w-[400px] rounded-[42px] bg-gradient-desktop p-[2px] 2xl:w-[270px] 3xl:w-[300px]">
                     <div className="flex flex-col gap-1 rounded-[42px] bg-[#1F203F] p-3">
-                        {categoryOptions.map((option) => (
+                        {options.map((option) => (
                             <SelectItem
                                 key={option.value}
                                 value={option.value}
@@ -130,7 +123,6 @@ const EventsSelectSearchDesktop: React.FC<IEventsSelectSearch> = ({ selectedOpti
         </div>
     )
 }
-
 
 const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipMessage: string }>(
     ({ children, isChecked, onClick, tooltipMessage, ...props }, forwardedRef) => {
@@ -151,7 +143,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipMessa
                     }
                 }}
             >
-                <div className="flex ">
+                <div className="flex items-center">
                     <div className="relative flex size-[20px] items-center justify-center">
                         <input
                             type="checkbox"
@@ -177,20 +169,19 @@ const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipMessa
                                     border: '2px solid #878797',
                                     background: 'transparent',
                                 }}
-                            ></div>
+                            />
                         )}
                     </div>
                     <div className="pl-[14px]">{children}</div>
                 </div>
-                <div className="justify-items-center">
-                    <HelpEventsTooltipDesktop tooltipMessage={tooltipMessage} />
 
+                <div className="flex items-center">
+                    <HelpEventsTooltipDesktop tooltipMessage={tooltipMessage} />
+                    <QuestionMarkDesktop />
                 </div>
-                <div className="pl-[14px]">{children}</div>
             </div>
-            <QuestionMarkDesktop />
-        </div>
-    ),
+        )
+    },
 )
 
 SelectItem.displayName = 'SelectItem'

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -128,7 +128,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipText:
     ({ children, isChecked, onClick, tooltipText, ...props }, forwardedRef) => {
         return (
             <div
-                className={`relative z-[3] flex cursor-pointer items-center justify-between rounded-[18px] p-[15px] text-[15px] font-medium ${
+                className={`relative flex cursor-pointer items-center justify-between rounded-[18px] p-[15px] text-[15px] font-medium ${
                     isChecked ? 'bg-[#5F4AF30F] text-white' : 'bg-transparent text-[#878797]'
                 }`}
                 {...props}

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -15,7 +15,7 @@ interface ISelectItem {
 interface ISelectOption {
     value: string
     label: string
-    tooltipText: string
+    tooltipMessage: string
 }
 
 const EventsSelectSearchDesktop = () => {
@@ -50,37 +50,37 @@ const EventsSelectSearchDesktop = () => {
         {
             value: 'fairs',
             label: 'Выставки/презентации',
-            tooltipText:
+            tooltipMessage:
                 'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
         },
         {
             value: 'open_days',
             label: 'Дни открытых дверей',
-            tooltipText:
+            tooltipMessage:
                 'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
         },
         {
             value: 'conferences',
             label: 'Конференции',
-            tooltipText:
+            tooltipMessage:
                 'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
         },
         {
             value: 'master_classes',
             label: 'Мастер-классы/семинары/тренинги',
-            tooltipText:
+            tooltipMessage:
                 'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
         },
         {
             value: 'internships',
             label: 'Стажировки',
-            tooltipText:
+            tooltipMessage:
                 'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
         },
         {
             value: 'job_fairs',
             label: 'Ярмарки вакансий',
-            tooltipText:
+            tooltipMessage:
                 'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
         },
     ]
@@ -112,7 +112,7 @@ const EventsSelectSearchDesktop = () => {
                                 value={option.value}
                                 isChecked={selectedOptions.includes(option.value)}
                                 onClick={() => toggleOption(option.value)}
-                                tooltipText={option.tooltipText}
+                                tooltipMessage={option.tooltipMessage}
                             >
                                 {option.label}
                             </SelectItem>
@@ -124,8 +124,8 @@ const EventsSelectSearchDesktop = () => {
     )
 }
 
-const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipText: string }>(
-    ({ children, isChecked, onClick, tooltipText, ...props }, forwardedRef) => {
+const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipMessage: string }>(
+    ({ children, isChecked, onClick, tooltipMessage, ...props }, forwardedRef) => {
         return (
             <div
                 className={`relative flex cursor-pointer items-center justify-between rounded-[18px] p-[15px] text-[15px] font-medium ${
@@ -175,7 +175,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipText:
                     <div className="pl-[14px]">{children}</div>
                 </div>
                 <div className="justify-items-center">
-                    <HelpEventsTooltipDesktop tooltipMessage={tooltipText} />
+                    <HelpEventsTooltipDesktop tooltipMessage={tooltipMessage} />
                 </div>
             </div>
         )

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsSelectSearchDesktop.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import React, { useEffect, useRef, useState } from 'react'
-import { ChevronDownIconDesktop, CheckedBoxIconDesktop, QuestionMarkDesktop } from '@/components/assets/iconsDesktop'
+import { ChevronDownIconDesktop, CheckedBoxIconDesktop } from '@/components/assets/iconsDesktop'
 import { Button } from '@/components/ui/button'
+import { HelpEventsTooltipDesktop } from '@/components/ui/tooltip'
 
 interface ISelectItem {
     value: string
@@ -14,6 +15,7 @@ interface ISelectItem {
 interface ISelectOption {
     value: string
     label: string
+    tooltipText: string
 }
 
 const EventsSelectSearchDesktop = () => {
@@ -45,12 +47,42 @@ const EventsSelectSearchDesktop = () => {
     }, [])
 
     const options: ISelectOption[] = [
-        { value: 'fairs', label: 'Выставки/презентации' },
-        { value: 'open_days', label: 'Дни открытых дверей' },
-        { value: 'conferences', label: 'Конференции' },
-        { value: 'master_classes', label: 'Мастер-классы/семинары/тренинги' },
-        { value: 'internships', label: 'Стажировки' },
-        { value: 'job_fairs', label: 'Ярмарки вакансий' },
+        {
+            value: 'fairs',
+            label: 'Выставки/презентации',
+            tooltipText:
+                'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
+        },
+        {
+            value: 'open_days',
+            label: 'Дни открытых дверей',
+            tooltipText:
+                'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
+        },
+        {
+            value: 'conferences',
+            label: 'Конференции',
+            tooltipText:
+                'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
+        },
+        {
+            value: 'master_classes',
+            label: 'Мастер-классы/семинары/тренинги',
+            tooltipText:
+                'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
+        },
+        {
+            value: 'internships',
+            label: 'Стажировки',
+            tooltipText:
+                'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
+        },
+        {
+            value: 'job_fairs',
+            label: 'Ярмарки вакансий',
+            tooltipText:
+                'Мероприятия, где компании представляют свои продукты, услуги или достижения. Полезно для знакомства с компаниями и их деятельностью.',
+        },
     ]
 
     return (
@@ -80,6 +112,7 @@ const EventsSelectSearchDesktop = () => {
                                 value={option.value}
                                 isChecked={selectedOptions.includes(option.value)}
                                 onClick={() => toggleOption(option.value)}
+                                tooltipText={option.tooltipText}
                             >
                                 {option.label}
                             </SelectItem>
@@ -91,8 +124,8 @@ const EventsSelectSearchDesktop = () => {
     )
 }
 
-const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem>(
-    ({ children, isChecked, onClick, ...props }, forwardedRef) => {
+const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem & { tooltipText: string }>(
+    ({ children, isChecked, onClick, tooltipText, ...props }, forwardedRef) => {
         return (
             <div
                 className={`relative z-[3] flex cursor-pointer items-center justify-between rounded-[18px] p-[15px] text-[15px] font-medium ${
@@ -141,8 +174,8 @@ const SelectItem = React.forwardRef<HTMLDivElement, ISelectItem>(
                     </div>
                     <div className="pl-[14px]">{children}</div>
                 </div>
-                <div className="justify-items-end">
-                    <QuestionMarkDesktop />
+                <div className="justify-items-center">
+                    <HelpEventsTooltipDesktop tooltipMessage={tooltipText} />
                 </div>
             </div>
         )

--- a/frontend-react/components/ui/tooltip.tsx
+++ b/frontend-react/components/ui/tooltip.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import { cn } from '@/lib/utils'
-import { HelpIconDesktop, TrashIconDesktop } from '@/components/assets/iconsDesktop'
+import { HelpIconDesktop, TrashIconDesktop, QuestionMarkDesktop } from '@/components/assets/iconsDesktop'
 import { HelpIconMobi } from '@/components/assets/iconsMobi'
 
 interface IHelpTooltip {
@@ -170,6 +170,35 @@ export const TrashTooltipDesktop: React.FC<IHelpTooltip> = ({ tooltipMessage }) 
                 arrowPadding={0}
                 avoidCollisions={false}
                 collisionPadding={{ top: 10, left: 20 }}
+            >
+                <div className="4xl:p-1.5 3xl:p-1.5 3xl:pt-1 p-2 2xl:p-1.5 2xl:pt-1">
+                    <p className="3xl:text-[12px] 3xl:font-light text-mauve12 align-baseline text-[15px] font-medium leading-[19px] text-white 2xl:text-[12px] 2xl:font-light">
+                        {tooltipMessage}
+                    </p>
+                </div>
+                <TooltipArrow className="transform: translateY(-1px) h-2 fill-[#353652cc]" />
+            </TooltipContent>
+        </Tooltip>
+    </TooltipProvider>
+)
+
+export const HelpEventsTooltipDesktop: React.FC<IHelpTooltip> = ({ tooltipMessage }) => (
+    <TooltipProvider delayDuration={200}>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button className="flex self-end justify-self-end 3xl:ml-2">
+                    <QuestionMarkDesktop />
+                </button>
+            </TooltipTrigger>
+            <TooltipContent
+                className="3xl:max-w-[310px] m-0 h-full max-h-screen w-[385px] rounded-[25px] border-none bg-[#353652cc] shadow-none 2xl:max-w-[278px]"
+                sideOffset={3}
+                side="bottom"
+                align="start"
+                alignOffset={-20}
+                arrowPadding={0}
+                avoidCollisions={false}
+                collisionPadding={{ top: 20, left: 20 }}
             >
                 <div className="4xl:p-1.5 3xl:p-1.5 3xl:pt-1 p-2 2xl:p-1.5 2xl:pt-1">
                     <p className="3xl:text-[12px] 3xl:font-light text-mauve12 align-baseline text-[15px] font-medium leading-[19px] text-white 2xl:text-[12px] 2xl:font-light">

--- a/frontend-react/components/ui/tooltip.tsx
+++ b/frontend-react/components/ui/tooltip.tsx
@@ -191,7 +191,7 @@ export const HelpEventsTooltipDesktop: React.FC<IHelpTooltip> = ({ tooltipMessag
                 </button>
             </TooltipTrigger>
             <TooltipContent
-                className="3xl:max-w-[310px] m-0 h-full max-h-screen w-[385px] rounded-[25px] border-none bg-[#353652cc] shadow-none 2xl:max-w-[278px]"
+                className="z-[9999] 3xl:max-w-[310px] m-0 h-full max-h-screen w-[385px] rounded-[25px] border-none bg-[#353652cc] shadow-none 2xl:max-w-[278px]"
                 sideOffset={3}
                 side="bottom"
                 align="start"


### PR DESCRIPTION
Задача: при наведении на иконку "?" категории из дропдаун-меню Мероприятия должен всплывать поп-ап/тултип с разъяснениями (на десктопе)

Сделано: 
- в интерфейс ISelectOption добавлено поле для всплывающего текста, в соответствующую переменную добавлен текст всплывающего сообщения (пока одинаковый для всех категорий)
- создан отдельный тултип HelpEventsTooltipDesktop на базе имеющегося интерфейса IHelpTooltip и компонента HelpTooltipDesktop
- изменен z-index в компоненте SelectItem для того, чтобы убрать эффект просвечивания иконки сквозь всплывающий текст (без удаления существовавшего z-[3] этого сделать не удавалось - насколько вижу, без него дропдаун отображается так же, как и раньше)

<img width="1868" height="1113" alt="Снимок экрана 2025-08-03 182801" src="https://github.com/user-attachments/assets/dd816798-5430-4937-a8b9-7f707c87fc29" />
<img width="1949" height="1081" alt="Снимок экрана 2025-08-03 183127" src="https://github.com/user-attachments/assets/e86639dd-1394-4842-833c-f4a66c7db1a5" />


Комментарии:
При тестировании поведения (всплывающий текст не должен мешать кликам по чекбоксам слева от названия категорий) обнаружено: 
- разночтения в макете и коде: выбранный чекбокс на макете окрашен в белый, а в текущей реализации - сине-фиолетовым градиентом
- на расширении 1440 и ниже (а точнее, начиная где-то с ~1550) чекбокс напротив категории Мастерклассы "сжимается" и отображается некорректно (см скриншот)