### PR TITLE
FF 230 fix/professions input focus mobi

### DIFF
--- a/frontend-react/components/mobi/pageMobi/ProfessionsPageMobi/ProfessionsPageMobi.tsx
+++ b/frontend-react/components/mobi/pageMobi/ProfessionsPageMobi/ProfessionsPageMobi.tsx
@@ -58,7 +58,7 @@ const ProfessionsPageMobi: React.FC = () => {
                             <div className="relative w-full max-w-[386px] rounded-full [@media(min-width:617px)]:max-w-[600px]">
                                 <EnhancedInput
                                     type="text"
-                                    className="pl-[20px] text-white"
+                                    className="pl-[20px] pr-[50px] text-white"
                                     value={searchQuery}
                                     onChange={(value) => setSearchQuery(value)}
                                     variant={'search_mobi'}


### PR DESCRIPTION
- Fixed input background in focus on the Professions page (mobi). When focused, the input background of the Professions mobile page had side indents, now there are no indents. 

- Edited paddings of indents according to the layout.

Picture before:
![Скриншот 17-08-2025 173159](https://github.com/user-attachments/assets/8b8a5a4c-534c-43d4-97bb-43c0d9a200b2)

Picture after:
![Скриншот 17-08-2025 192324](https://github.com/user-attachments/assets/7fbf754e-465b-4d58-8ea5-2001fa9a7213)

