### PR TITLE
FF-234/fix modalcallmobi

### DIFF
--- a/frontend-react/modals/ModalsMobi/ModalCallMobi.tsx
+++ b/frontend-react/modals/ModalsMobi/ModalCallMobi.tsx
@@ -177,7 +177,7 @@ const ModalCallMobi: React.FC<IModalContent> = ({ onClose }) => {
                         <button
                             type="submit"
                             disabled={Object.values(errors).some((err) => err?.trim())}
-                            className={`mx-auto mt-[1.8rem] w-full max-w-[294px] whitespace-nowrap rounded-[50px] bg-sub-title-gradient-mobi py-[0.91rem] px-[1rem] min-[320px]:px-[4.09rem] md:px-[4.09rem] text-white font-semibold ${
+                            className={`bg-sub-title-gradient-mobi mx-auto mt-[30px] h-12 w-4/5 rounded-[50px] text-3xl font-semibold text-white md:text-4xl ${
                                 Object.values(errors).some((err) => err?.trim())
                                     ? 'bg-[#878797] disabled:opacity-100'
                                     : 'bg-sub-title-gradient-mobi'
@@ -191,8 +191,8 @@ const ModalCallMobi: React.FC<IModalContent> = ({ onClose }) => {
 
             {step === 'accepted' && (
                 <Modal variant="mobile" size="mobile-346" onClose={onClose} bgClass="bg-auto" className="z-[70]">
-                    <h2 className="bg-sub-title-gradient-mobi bg-clip-text pb-4 text-center text-4xl font-semibold text-transparent md:text-4xl">
-                        ЗАЯВКА ПРИНЯТА
+                    <h2 className="bg-sub-title-gradient-mobi uppercase bg-clip-text pb-4 text-center text-4xl font-semibold text-transparent md:text-4xl">
+                        Заявка принята
                     </h2>
                     <p className="mb-1 px-3 pb-[18px] text-justify text-xl font-medium leading-[17px] text-[#878797] md:text-lg">
                         Мы с вами свяжемся в ближайшее время, а пока вы можете ознакомиться с нашими услугами на сайте.


### PR DESCRIPTION
Change the modal window of ordering a call in the mobile version under the layout. Remove the extra lines, change margins and padding. Used a Pixel-Perfect plugin.

Picture before:
![223033](https://github.com/user-attachments/assets/1b08e15e-2e08-4bb1-ae65-604cde89bed0)

Picture after: 
![133904](https://github.com/user-attachments/assets/50121c9d-0cac-4c9d-af05-39a102147547)

Picture with a mesh of a Pixel-Perfect plugin:
![133830](https://github.com/user-attachments/assets/1a743837-29c4-4688-b72d-764647b0773c)