### PR TITLE
FF-238-fix Mobile card layout: button alignment and bottom spacing

### DIFF
--- a/frontend-react/components/mobi/pageMobi/HomePageMobi/components/HeaderCardsMobi/ItemHeaderCardsMobi/HeaderCardsItemMobi.tsx
+++ b/frontend-react/components/mobi/pageMobi/HomePageMobi/components/HeaderCardsMobi/ItemHeaderCardsMobi/HeaderCardsItemMobi.tsx
@@ -36,7 +36,7 @@ const HeaderCardsItemMobi: React.FC<IHeaderCardItem> = ({
                 }}
             >
                 <HelpTooltipMobi tooltipMessage={tooltipMessage} />
-                <div className="relative flex h-full w-full flex-col items-center justify-center gap-[17px] pb-8">
+                <div className="relative flex h-full w-full flex-col items-center justify-center gap-[17px]">
                     <div className="flex flex-col items-center justify-center text-center">
                         <div className="sm_s:text-3xl sm_s:leading-[24px] px-[30px] text-justify text-5xl font-medium leading-[32px] text-white sm:text-3xl sm:leading-[24px]">
                             {textBlack}{' '}
@@ -49,7 +49,7 @@ const HeaderCardsItemMobi: React.FC<IHeaderCardItem> = ({
                             {price} <span translate={disableCurrencyTranslation ? 'no' : 'yes'}>{currency}</span>
                         </div>
                     </div>
-                    <Button variant="circleBlue" size="circleMobi" className="absolute bottom-[1px] right-0">
+                    <Button variant="circleBlue" size="circleMobi" className="absolute bottom-0 right-0">
                         <ArrowWhiteMobi />
                     </Button>
                 </div>


### PR DESCRIPTION
1. Выравнивание кнопки внутри карточки на мобильных устройствах. 2. Устранено визуальное обрезание нижнего края фона. 3. Проверено заключительное отображение в Chrome (скрин1 - на Iphone 12pro) и Firefox (скрин2 - на GalaxyS20 Android11) 4. Изменения внесены только в HeaderCardsItemMobi.tsx
<img width="606" height="892" alt="screen chrome iphone 12pro" src="https://github.com/user-attachments/assets/e9caf022-99e3-49bd-9789-d4c440cd9dc9" />
<img width="886" height="850" alt="screen firefox galaxyS20 android11" src="https://github.com/user-attachments/assets/6c75271d-2ce4-43a2-91c3-6384170f5fc3" />
