### PR TITLE
FF-237/fix-paddings-events-desktop

### DIFF
--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -98,7 +98,10 @@ const EventsPageDesktop: React.FC = () => {
                                 </p>
                             </div>
                         ) : (
-                            <div className="3xl:gap-[25px] 4xl:gap-[30px] flex min-h-[40vh] flex-wrap justify-center gap-[36px] 2xl:gap-[20px]">
+                            <div
+                                className="3xl:gap-[25px] 4xl:gap-[30px] flex min-h-[40vh] flex-wrap justify-between 
+                                gap-[36px] 2xl:gap-[20px]"
+                            >
                                 {pagedEvents.map((item) => (
                                     <EventsCardDesktop key={item.id} {...item} />
                                 ))}

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/EventsPageDesktop.tsx
@@ -99,8 +99,9 @@ const EventsPageDesktop: React.FC = () => {
                             </div>
                         ) : (
                             <div
-                                className="3xl:gap-[25px] 4xl:gap-[30px] flex min-h-[40vh] flex-wrap justify-between 
-                                gap-[36px] 2xl:gap-[20px]"
+                                className="grid grid-cols-3 xl:grid-cols-2
+                                gap-[36px] min-h-[40vh] w-full"
+                                style={{ gridAutoRows: '1fr' }}
                             >
                                 {pagedEvents.map((item) => (
                                     <EventsCardDesktop key={item.id} {...item} />

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsCardDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsCardDesktop.tsx
@@ -36,9 +36,10 @@ const EventsCardDesktop: React.FC<IEventsCard> = ({
         <>
             <div
                 data-category={category}
-                className="flex min-h-[657px] max-w-[474px] 3xl:max-w-[414px]
-                2xl:max-w-[398px]
-                items-center justify-center rounded-[3.125rem] drop-shadow-[0_4px_4px_rgba(0,0,0,0.25)]"
+                className="relative flex flex-col
+                aspect-[474/657]
+                flex-1
+                justify-start rounded-[3.125rem] drop-shadow-[0_4px_4px_rgba(0,0,0,0.25)]"
                 style={{
                     backgroundImage: "url('/background/subtract-events.png')",
                     backgroundSize: 'contain',
@@ -47,8 +48,8 @@ const EventsCardDesktop: React.FC<IEventsCard> = ({
                 }}
             >
                 <div>
-                    <div className="relative mx-[20px] mb-[40px] mt-[20px] flex flex-col gap-[26px]">
-                        <div className="relative aspect-[4/3] w-full">
+                    <div className="px-[20px] pt-[20px] flex flex-col gap-[20px]">
+                        <div className="relative aspect-[434/358] w-full">
                             <Image
                                 src={image}
                                 fill
@@ -57,7 +58,9 @@ const EventsCardDesktop: React.FC<IEventsCard> = ({
                             />
                         </div>
 
-                        <div className="text28px_events text-gradient_desktop_custom pb-[4px] uppercase">{title}</div>
+                        <div className=" text28px_desktop text-gradient_desktop_custom pb-[5px] uppercase leading-tight">
+                            {title}
+                        </div>
                         <div className="text18px_desktop flex gap-[15px]">
                             <MapDesktop /> {date} ({week}) в {time}
                         </div>
@@ -70,7 +73,7 @@ const EventsCardDesktop: React.FC<IEventsCard> = ({
                         <Button
                             variant="circleDarkBlue"
                             size="circle_desktop"
-                            className="absolute -right-4 2xl:-bottom-[4.3rem] 2xl:-right-[1.2rem] -bottom-[4.1rem] 2xl:h-18 3xl:h-[4rem] 2xl:p-[16px]"
+                            className="absolute -right-0 -bottom-0 2xl:h-18 3xl:h-[4rem] 2xl:p-[16px]"
                         >
                             <ForwardIconWhiteDesktop />
                         </Button>

--- a/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsCardDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/EventsPageDesktop/components/EventsCardDesktop.tsx
@@ -36,7 +36,9 @@ const EventsCardDesktop: React.FC<IEventsCard> = ({
         <>
             <div
                 data-category={category}
-                className="flex min-h-[657px] max-w-[474px] items-center justify-center rounded-[3.125rem] drop-shadow-[0_4px_4px_rgba(0,0,0,0.25)]"
+                className="flex min-h-[657px] max-w-[474px] 3xl:max-w-[414px]
+                2xl:max-w-[398px]
+                items-center justify-center rounded-[3.125rem] drop-shadow-[0_4px_4px_rgba(0,0,0,0.25)]"
                 style={{
                     backgroundImage: "url('/background/subtract-events.png')",
                     backgroundSize: 'contain',


### PR DESCRIPTION
- Поменяла flex контейнеру свойство на justify-between
- Сверила сетку и основные отступы(сами карточки не трогала)

Обратить внимание: Расстояние между карточками по бокам (gap-36) сходится, а по вертикальной оси (верх/вниз) по макету 40px - не сходится, но тк там единый gap я править не стала.
Если нужно на других брейкпоинтах центрировать, то могу добавить доп. стили.

<img width="1440" height="900" alt="Снимок экрана 2025-08-24 в 03 28 32" src="https://github.com/user-attachments/assets/935656ce-f63f-4f17-bdaf-4d186c6d2ce8" />
<img width="1440" height="900" alt="Снимок экрана 2025-08-24 в 03 28 46" src="https://github.com/user-attachments/assets/1af84b33-900e-4373-8d5b-3e654a471a72" />
