### PR TITLE
FF-193-home-page-events-desktop-mobi

### DIFF
--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/HomePageDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/HomePageDesktop.tsx
@@ -22,7 +22,7 @@ const HomePageDesktop: React.FC = () => {
             openModal(modalKey, modalType)
             localStorage.setItem('hasSeenCookies', 'true')
         }
-    }, [])
+    }, [openModal])
 
     return (
         <>

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/EventsSectionDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/EventsSectionDesktop.tsx
@@ -6,38 +6,10 @@ import ItemEventsDesktop from './ItemEventsDesktop/ItemEventsDesktop'
 import { contentEventsSection } from './contentEventsSectionDesktop/content'
 import useScrollbarSync from '@/hooks/useScrollbarSync'
 import { useDataContext } from '@/context/DataContext'
+import { getEventsToShow } from '@/lib/homeEventsSortCards'
 
-const SHOW_BACKEND_EVENTS = true
+const SHOW_BACKEND_EVENTS = false
 const EVENTS_TO_SHOW_COUNT = 6
-
-export const MONTHS = [
-    'Января',
-    'Февраля',
-    'Марта',
-    'Апреля',
-    'Мая',
-    'Июня',
-    'Июля',
-    'Августа',
-    'Сентября',
-    'Октября',
-    'Ноября',
-    'Декабря',
-]
-
-function parseEventDate(dateStr: string): Date | null {
-    const iso = new Date(dateStr)
-    if (!isNaN(iso.getTime())) return iso
-
-    const [dayRaw, monthRaw] = dateStr.split(' ')
-    const day = Number(dayRaw)
-    const monthIndex = MONTHS.findIndex((m) => m.toLowerCase() === (monthRaw ?? '').toLowerCase())
-    if (!isNaN(day) && monthIndex >= 0) {
-        const year = new Date().getFullYear()
-        return new Date(year, monthIndex, day)
-    }
-    return null
-}
 
 const EventsSectionDesktop: React.FC = () => {
     const { events } = useDataContext()
@@ -46,15 +18,7 @@ const EventsSectionDesktop: React.FC = () => {
     const { scrollContentWidth } = useScrollbarSync(contentRef, scrollbarRef)
 
     const eventSource = SHOW_BACKEND_EVENTS && events && events.length > 0 ? events : contentEventsSection
-
-    const sortedEvents = eventSource.slice().sort((a, b) => {
-        const dateA = parseEventDate(a.date)
-        const dateB = parseEventDate(b.date)
-        if (!dateA || !dateB) return 0
-        return dateB.getTime() - dateA.getTime()
-    })
-
-    const eventsToShow = sortedEvents.slice(0, EVENTS_TO_SHOW_COUNT)
+    const eventsToShow = getEventsToShow(eventSource, EVENTS_TO_SHOW_COUNT)
 
     return (
         <div className="py-[10vh]">

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/EventsSectionDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/EventsSectionDesktop.tsx
@@ -5,11 +5,56 @@ import TitleDesktop from '@/components/desktop/shared/TitleDesktop'
 import ItemEventsDesktop from './ItemEventsDesktop/ItemEventsDesktop'
 import { contentEventsSection } from './contentEventsSectionDesktop/content'
 import useScrollbarSync from '@/hooks/useScrollbarSync'
+import { useDataContext } from '@/context/DataContext'
+
+const SHOW_BACKEND_EVENTS = true
+const EVENTS_TO_SHOW_COUNT = 6
+
+export const MONTHS = [
+    'Января',
+    'Февраля',
+    'Марта',
+    'Апреля',
+    'Мая',
+    'Июня',
+    'Июля',
+    'Августа',
+    'Сентября',
+    'Октября',
+    'Ноября',
+    'Декабря',
+]
+
+function parseEventDate(dateStr: string): Date | null {
+    const iso = new Date(dateStr)
+    if (!isNaN(iso.getTime())) return iso
+
+    const [dayRaw, monthRaw] = dateStr.split(' ')
+    const day = Number(dayRaw)
+    const monthIndex = MONTHS.findIndex((m) => m.toLowerCase() === (monthRaw ?? '').toLowerCase())
+    if (!isNaN(day) && monthIndex >= 0) {
+        const year = new Date().getFullYear()
+        return new Date(year, monthIndex, day)
+    }
+    return null
+}
 
 const EventsSectionDesktop: React.FC = () => {
+    const { events } = useDataContext()
     const contentRef = useRef<HTMLDivElement>(null)
     const scrollbarRef = useRef<HTMLDivElement>(null)
     const { scrollContentWidth } = useScrollbarSync(contentRef, scrollbarRef)
+
+    const eventSource = SHOW_BACKEND_EVENTS && events && events.length > 0 ? events : contentEventsSection
+
+    const sortedEvents = eventSource.slice().sort((a, b) => {
+        const dateA = parseEventDate(a.date)
+        const dateB = parseEventDate(b.date)
+        if (!dateA || !dateB) return 0
+        return dateB.getTime() - dateA.getTime()
+    })
+
+    const eventsToShow = sortedEvents.slice(0, EVENTS_TO_SHOW_COUNT)
 
     return (
         <div className="py-[10vh]">
@@ -20,8 +65,8 @@ const EventsSectionDesktop: React.FC = () => {
                 ref={contentRef}
                 className="no-scrollbar_custom container mt-[6vh] flex select-none gap-8 overflow-x-scroll"
             >
-                {contentEventsSection.map((item) => (
-                    <ItemEventsDesktop image={item.image} title={item.title} date={item.date} key={item.id} />
+                {eventsToShow.map((item) => (
+                    <ItemEventsDesktop image={item.imagePath} title={item.name} date={item.date} key={item.id} />
                 ))}
             </div>
             <div className="container mt-[58px]">

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef } from 'react'
 import Image from 'next/image'
+import { MONTHS } from '../EventsSectionDesktop'
 
 interface IEventSection {
     image: string
@@ -9,8 +10,20 @@ interface IEventSection {
     date: string
 }
 
+function parseDateForDisplay(dateStr: string): { day: string; month: string } {
+    const jsDate = new Date(dateStr)
+    if (!isNaN(jsDate.getTime())) {
+        const day = jsDate.getDate().toString().padStart(2, '0')
+        const month = MONTHS[jsDate.getMonth()]
+        return { day, month }
+    }
+
+    const [dayRaw, monthRaw] = dateStr.split(' ')
+    return { day: dayRaw || '', month: monthRaw || '' }
+}
+
 const ItemEventsDesktop: React.FC<IEventSection> = ({ image, title, date }) => {
-    const [day, month] = date.split(' ')
+    const { day, month } = parseDateForDisplay(date)
 
     const itemRef = useRef<HTMLDivElement>(null)
 
@@ -24,13 +37,13 @@ const ItemEventsDesktop: React.FC<IEventSection> = ({ image, title, date }) => {
                     className="pointer-events-none select-none rounded-[3.125rem] object-cover 2xl:rounded-[2rem]"
                 />
                 <div className="absolute right-[5%] top-[4%] flex aspect-[113/100] w-[22%] flex-col items-center justify-center rounded-3xl bg-white bg-opacity-[80%] 2xl:rounded-2xl">
-                    <p className="4xl:text-7xl 3xl:text-6xl text-9xl font-semibold text-[#1f203f] 2xl:text-4xl">
+                    <p className="text-9xl font-semibold text-[#1f203f] 2xl:text-4xl 3xl:text-6xl 4xl:text-7xl">
                         {day}
                     </p>
-                    <p className="4xl:text-2xl 3xl:text-xl text-4xl font-medium text-[#878797] 2xl:text-lg">{month}</p>
+                    <p className="text-4xl font-medium text-[#878797] 2xl:text-lg 3xl:text-xl 4xl:text-2xl">{month}</p>
                 </div>
             </div>
-            <p className="4xl:text-7xl 3xl:text-6xl line-clamp-2 max-h-[calc(2*2.5rem)] overflow-hidden text-ellipsis pt-5 text-9xl font-medium uppercase leading-[1.2] text-white 2xl:text-4xl">
+            <p className="line-clamp-2 max-h-[calc(2*2.5rem)] overflow-hidden text-ellipsis pt-5 text-9xl font-medium uppercase leading-[1.2] text-white 2xl:text-4xl 3xl:text-6xl 4xl:text-7xl">
                 {title}
             </p>
         </div>

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef } from 'react'
 import Image from 'next/image'
-import { MONTHS } from '../EventsSectionDesktop'
+import { MONTHS, parseEventDate } from '@/lib/homeEventsSortCards'
 
 interface IEventSection {
     image: string
@@ -10,14 +10,25 @@ interface IEventSection {
     date: string
 }
 
+// function parseDateForDisplay(dateStr: string): { day: string; month: string } {
+//     const jsDate = new Date(dateStr)
+//     if (!isNaN(jsDate.getTime())) {
+//         const day = jsDate.getDate().toString().padStart(2, '0')
+//         const month = MONTHS[jsDate.getMonth()]
+//         return { day, month }
+//     }
+
+//     const [dayRaw, monthRaw] = dateStr.split(' ')
+//     return { day: dayRaw || '', month: monthRaw || '' }
+// }
+
 function parseDateForDisplay(dateStr: string): { day: string; month: string } {
-    const jsDate = new Date(dateStr)
-    if (!isNaN(jsDate.getTime())) {
+    const jsDate = parseEventDate(dateStr)
+    if (jsDate) {
         const day = jsDate.getDate().toString().padStart(2, '0')
         const month = MONTHS[jsDate.getMonth()]
         return { day, month }
     }
-
     const [dayRaw, monthRaw] = dateStr.split(' ')
     return { day: dayRaw || '', month: monthRaw || '' }
 }

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/ItemEventsDesktop/ItemEventsDesktop.tsx
@@ -2,35 +2,12 @@
 
 import React, { useRef } from 'react'
 import Image from 'next/image'
-import { MONTHS, parseEventDate } from '@/lib/homeEventsSortCards'
+import { parseDateForDisplay } from '@/lib/homeEventsSortCards'
 
 interface IEventSection {
     image: string
     title: string
     date: string
-}
-
-// function parseDateForDisplay(dateStr: string): { day: string; month: string } {
-//     const jsDate = new Date(dateStr)
-//     if (!isNaN(jsDate.getTime())) {
-//         const day = jsDate.getDate().toString().padStart(2, '0')
-//         const month = MONTHS[jsDate.getMonth()]
-//         return { day, month }
-//     }
-
-//     const [dayRaw, monthRaw] = dateStr.split(' ')
-//     return { day: dayRaw || '', month: monthRaw || '' }
-// }
-
-function parseDateForDisplay(dateStr: string): { day: string; month: string } {
-    const jsDate = parseEventDate(dateStr)
-    if (jsDate) {
-        const day = jsDate.getDate().toString().padStart(2, '0')
-        const month = MONTHS[jsDate.getMonth()]
-        return { day, month }
-    }
-    const [dayRaw, monthRaw] = dateStr.split(' ')
-    return { day: dayRaw || '', month: monthRaw || '' }
 }
 
 const ItemEventsDesktop: React.FC<IEventSection> = ({ image, title, date }) => {

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/contentEventsSectionDesktop/content.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/contentEventsSectionDesktop/content.tsx
@@ -1,45 +1,109 @@
+export function isToday(dateStr: string) {
+    const now = new Date()
+    const d = new Date(dateStr)
+    return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate()
+}
+
+export function isTomorrow(dateStr: string) {
+    const now = new Date()
+    const d = new Date(dateStr)
+    const tomorrow = new Date(now)
+    tomorrow.setDate(now.getDate() + 1)
+    return (
+        d.getFullYear() === tomorrow.getFullYear() &&
+        d.getMonth() === tomorrow.getMonth() &&
+        d.getDate() === tomorrow.getDate()
+    )
+}
+
+export function isThisWeek(dateStr: string) {
+    const now = new Date()
+    now.setHours(0, 0, 0, 0)
+    const d = new Date(dateStr)
+    d.setHours(0, 0, 0, 0)
+    const end = new Date(now)
+    end.setDate(now.getDate() + 7)
+    return d >= now && d < end
+}
+
+export function isThisMonth(dateStr: string) {
+    const now = new Date()
+    const d = new Date(dateStr)
+    return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth()
+}
+
+export function isInNext3Months(dateStr: string) {
+    const now = new Date()
+    const d = new Date(dateStr)
+    const in3Months = new Date(now)
+    in3Months.setMonth(now.getMonth() + 3)
+    return d >= now && d <= in3Months
+}
+
+function getInDaysISO(days: number): string {
+    const d = new Date()
+    d.setDate(d.getDate() + days)
+    return d.toISOString().slice(0, 10)
+}
+function getTodayISO(): string {
+    return getInDaysISO(0)
+}
+function getTomorrowISO(): string {
+    return getInDaysISO(1)
+}
+function getThisWeekISO(): string {
+    return getInDaysISO(3)
+}
+function getThisMonthISO(): string {
+    return getInDaysISO(10)
+}
+
+function getInNext3MonthsISO(): string {
+    return getInDaysISO(40)
+}
+
 interface IContent {
     name: string
     imagePath: string
     date: string
-    id: number
+    id: string
 }
 
 export const contentEventsSection: IContent[] = [
     {
         name: 'Длинное название мероприятия',
         imagePath: '/images/events_1.png',
-        date: '18 ноября',
-        id: 1931293,
+        date: getTodayISO(),
+        id: '1931293',
     },
     {
         name: 'Мероприятие длинное еще одно',
         imagePath: '/images/events_2.png',
-        date: '10 ноября',
-        id: 19345293,
+        date: getThisMonthISO(),
+        id: '19345293',
     },
     {
         name: 'Очень длинное название мероприятия супердлинное название',
         imagePath: '/images/events_3.png',
-        date: '9 декабря',
-        id: 1934535293,
+        date: getThisMonthISO(),
+        id: '1934535293',
     },
     {
         name: 'Название мероприятия',
         imagePath: '/images/events_1.png',
-        date: '19 декабря',
-        id: 193654564563,
+        date: getTomorrowISO(),
+        id: '193654564563',
     },
     {
         name: 'Очень длинное название мероприятия',
         imagePath: '/images/events_3.png',
-        date: '5 мая',
-        id: 1934543563,
+        date: getInNext3MonthsISO(),
+        id: '1934543563',
     },
     {
         name: 'Мероприятие',
         imagePath: '/images/events_2.png',
-        date: '28 июня',
-        id: 19345487887,
+        date: getThisWeekISO(),
+        id: '19345487887',
     },
 ]

--- a/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/contentEventsSectionDesktop/content.tsx
+++ b/frontend-react/components/desktop/pageDesktop/HomePageDesktop/components/EventsSectionDesktop/contentEventsSectionDesktop/content.tsx
@@ -1,44 +1,44 @@
 interface IContent {
-    title: string
-    image: string
+    name: string
+    imagePath: string
     date: string
     id: number
 }
 
 export const contentEventsSection: IContent[] = [
     {
-        title: 'Длинное название мероприятия',
-        image: '/images/events_1.png',
+        name: 'Длинное название мероприятия',
+        imagePath: '/images/events_1.png',
         date: '18 ноября',
         id: 1931293,
     },
     {
-        title: 'Мероприятие длинное еще одно',
-        image: '/images/events_2.png',
+        name: 'Мероприятие длинное еще одно',
+        imagePath: '/images/events_2.png',
         date: '10 ноября',
         id: 19345293,
     },
     {
-        title: 'Очень длинное название мероприятия супердлинное название',
-        image: '/images/events_3.png',
+        name: 'Очень длинное название мероприятия супердлинное название',
+        imagePath: '/images/events_3.png',
         date: '9 декабря',
         id: 1934535293,
     },
     {
-        title: 'Название мероприятия',
-        image: '/images/events_1.png',
+        name: 'Название мероприятия',
+        imagePath: '/images/events_1.png',
         date: '19 декабря',
         id: 193654564563,
     },
     {
-        title: 'Очень длинное название мероприятия',
-        image: '/images/events_3.png',
+        name: 'Очень длинное название мероприятия',
+        imagePath: '/images/events_3.png',
         date: '5 мая',
         id: 1934543563,
     },
     {
-        title: 'Мероприятие',
-        image: '/images/events_2.png',
+        name: 'Мероприятие',
+        imagePath: '/images/events_2.png',
         date: '28 июня',
         id: 19345487887,
     },

--- a/frontend-react/lib/constants/imageMaps.ts
+++ b/frontend-react/lib/constants/imageMaps.ts
@@ -10,6 +10,12 @@ export const imageMaps = {
         'Программист': '12.webp',
         'Финансист': '13.webp',
     },
+    events: {
+        '50': '50.webp',
+        '51': '51.webp',
+        '52': '52.webp',
+        '53': '53.webp',
+    },
 } as const
 
 export type ImageMapCategory = keyof typeof imageMaps
@@ -19,6 +25,7 @@ const norm = (s: string) => s.toLowerCase().trim().replace(/\s+/g, ' ')
 const SUBDIR: Record<ImageMapCategory, string | undefined> = {
     companies: 'facade',
     professions: undefined,
+    events: undefined,
 }
 const joinUrl = (...parts: Array<string | undefined>) =>
     parts
@@ -26,9 +33,14 @@ const joinUrl = (...parts: Array<string | undefined>) =>
         .map((p) => p!.replace(/^\/+|\/+$/g, ''))
         .join('/')
 
-export function getImagePath<T extends ImageMapCategory>(category: T, name: string): string {
+export function getImagePath<T extends ImageMapCategory>(category: T, key: string): string {
     const map = imageMaps[category] as Record<string, string>
-    const file = Object.entries(map).find(([k]) => norm(k) === norm(name))?.[1]
+    let file: string | undefined
+    if (category === 'events') {
+        file = map[key]
+    } else {
+        file = Object.entries(map).find(([k]) => norm(k) === norm(key))?.[1]
+    }
 
     return '/' + joinUrl('api/photo', category, SUBDIR[category], file)
 }

--- a/frontend-react/lib/graphql/queries/get_all_actual_events.ts
+++ b/frontend-react/lib/graphql/queries/get_all_actual_events.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client'
+
+export const GET_ALL_ACTUAL_EVENTS = gql`
+    query getCardsAllActualEvents {
+        getAllActualEvents {
+            id
+            date
+            description
+            name
+            publicPlaceName
+            site
+            price
+            time
+            organizer
+            city {
+                id
+                name
+            }
+            eventCategory {
+                id
+                category
+            }
+        }
+    }
+`

--- a/frontend-react/lib/homeEventsSortCards.ts
+++ b/frontend-react/lib/homeEventsSortCards.ts
@@ -1,4 +1,4 @@
-export const MONTHS = [
+const MONTHS = [
     'Января',
     'Февраля',
     'Марта',
@@ -24,6 +24,17 @@ export function parseEventDate(dateStr: string): Date | null {
         return new Date(year, monthIndex, day)
     }
     return null
+}
+
+export function parseDateForDisplay(dateStr: string): { day: string; month: string } {
+    const jsDate = parseEventDate(dateStr)
+    if (jsDate) {
+        const day = jsDate.getDate().toString().padStart(2, '0')
+        const month = MONTHS[jsDate.getMonth()]
+        return { day, month }
+    }
+    const [dayRaw, monthRaw] = dateStr.split(' ')
+    return { day: dayRaw || '', month: monthRaw || '' }
 }
 
 export function getEventsToShow<T extends { date: string }>(events: T[], EVENTS_TO_SHOW_COUNT = 6): T[] {

--- a/frontend-react/lib/homeEventsSortCards.ts
+++ b/frontend-react/lib/homeEventsSortCards.ts
@@ -1,0 +1,39 @@
+export const MONTHS = [
+    'Января',
+    'Февраля',
+    'Марта',
+    'Апреля',
+    'Мая',
+    'Июня',
+    'Июля',
+    'Августа',
+    'Сентября',
+    'Октября',
+    'Ноября',
+    'Декабря',
+]
+
+export function parseEventDate(dateStr: string): Date | null {
+    const iso = new Date(dateStr)
+    if (!isNaN(iso.getTime())) return iso
+    const [dayRaw, monthRaw] = dateStr.split(' ')
+    const day = Number(dayRaw)
+    const monthIndex = MONTHS.findIndex((m) => m.toLowerCase() === (monthRaw ?? '').toLowerCase())
+    if (!isNaN(day) && monthIndex >= 0) {
+        const year = new Date().getFullYear()
+        return new Date(year, monthIndex, day)
+    }
+    return null
+}
+
+export function getEventsToShow<T extends { date: string }>(events: T[], EVENTS_TO_SHOW_COUNT = 6): T[] {
+    return events
+        .slice()
+        .sort((a, b) => {
+            const dateA = parseEventDate(a.date)
+            const dateB = parseEventDate(b.date)
+            if (!dateA || !dateB) return 0
+            return dateA.getTime() - dateB.getTime()
+        })
+        .slice(0, EVENTS_TO_SHOW_COUNT)
+}

--- a/frontend-react/lib/servicesServer/initialLoader.ts
+++ b/frontend-react/lib/servicesServer/initialLoader.ts
@@ -1,7 +1,9 @@
 import { loadAvailableCompaniesServer } from './loadCompanies/loadAvailableCompaniesServer'
 import { loadExistingProfessionsServer } from './loadProfessions/loadAvailableExistingProfessions'
+import { loadAllActualEventsServer } from './loadEvents/loadAllActualEventsServer'
 import { ICompany } from '@/types/companies/company'
 import { IProfessions } from '@/types/professions/professions'
+import { IEvent } from '@/types/events/event'
 
 export const initialLoaders = [
     {
@@ -11,5 +13,9 @@ export const initialLoaders = [
     {
         key: 'professions',
         loader: async () => (await loadExistingProfessionsServer()) as IProfessions[],
+    },
+    {
+        key: 'events',
+        loader: async () => (await loadAllActualEventsServer()) as IEvent[],
     },
 ] as const

--- a/frontend-react/lib/servicesServer/loadEvents/loadAllActualEventsServer.ts
+++ b/frontend-react/lib/servicesServer/loadEvents/loadAllActualEventsServer.ts
@@ -1,0 +1,18 @@
+import { createApolloServerClient } from '@/lib/apollo/apolloClient'
+import { GET_ALL_ACTUAL_EVENTS } from '@/lib/graphql/queries/get_all_actual_events'
+import { IEvent } from '@/types/events/event'
+import { getImagePath } from '@/lib/constants/imageMaps'
+
+export async function loadAllActualEventsServer(): Promise<IEvent[]> {
+    const client = createApolloServerClient()
+
+    const { data } = await client.query({
+        query: GET_ALL_ACTUAL_EVENTS,
+        fetchPolicy: 'network-only',
+    })
+
+    return data.getAllActualEvents.map((event: IEvent) => ({
+        ...event,
+        imagePath: getImagePath('events', event.id),
+    }))
+}

--- a/frontend-react/types/context/data.ts
+++ b/frontend-react/types/context/data.ts
@@ -1,7 +1,9 @@
 import { ICompany } from '@/types/companies/company'
 import { IProfessions } from '@/types/professions/professions'
+import { IEvent } from '../events/event'
 
 export interface IDataContext {
     companies: ICompany[]
     professions: IProfessions[]
+    events: IEvent[]
 }

--- a/frontend-react/types/events/event.ts
+++ b/frontend-react/types/events/event.ts
@@ -1,0 +1,24 @@
+export interface IRawEvent {
+    id: string
+    date: string
+    description: string
+    name: string
+    publicPlaceName: string
+    site: string
+    price: string
+    time: string
+    organizer: string
+    city: {
+        id: string
+        name: string
+    }
+    eventCategory: {
+        id: string
+        category: string
+    }
+    __typename?: string
+}
+
+export interface IEvent extends IRawEvent {
+    imagePath: string
+}


### PR DESCRIPTION
<img width="1624" height="710" alt="image" src="https://github.com/user-attachments/assets/d50c7ff6-b880-4809-9acb-86edc8475d41" />

К бэку подключена секция Мероприятий для главной страницы, версия Desktop

Карточки мероприятий отображаются начиная от самых актуальных.
Возможность просмотра версии с контентом сохранена, чтобы ее активировать нужно изменить константу в компненте:
`const SHOW_BACKEND_EVENTS = true` на `false`