### PR TITLE
FF-250 toast UI

### DIFF
--- a/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
+++ b/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
@@ -7,7 +7,6 @@ import { Button } from '@/components/ui/button'
 import PhoneInputMobi from '@/components/mobi/shared/formInput/PhoneInputMobi'
 import Link from 'next/link'
 import { useToast } from '@/context/ToastContext'
-import { Description } from '@radix-ui/react-dialog'
 
 interface IFormData {
     name: string

--- a/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
+++ b/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
@@ -121,12 +121,12 @@ const JoinTeamMobi: React.FC = () => {
             200,
         )
 
-        const cleanedPhone = normalizePhone(formData.phoneNumber)
+        // const cleanedPhone = normalizePhone(formData.phoneNumber)
     }
 
-    const normalizePhone = (value: string) => {
-        return value.replace(/[^\d+]/g, '')
-    }
+    // const normalizePhone = (value: string) => {
+    //     return value.replace(/[^\d+]/g, '')
+    // }
 
     const renderErrors = () => {
         const hasFieldErrors = errors.name || errors.phoneNumber || errors.profession || errors.consent

--- a/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
+++ b/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import PhoneInputMobi from '@/components/mobi/shared/formInput/PhoneInputMobi'
 import Link from 'next/link'
 import { useToast } from '@/context/ToastContext'
+import { useRouter } from 'next/navigation'
 
 interface IFormData {
     name: string
@@ -41,6 +42,7 @@ const JoinTeamMobi: React.FC = () => {
     const [selectedFile, setSelectedFile] = useState<File | null>(null)
 
     const { toast } = useToast()
+    const router = useRouter()
 
     const openFileDialog = () => {
         fileInputRef.current?.click()
@@ -110,16 +112,21 @@ const JoinTeamMobi: React.FC = () => {
         const isValid = validateForm()
         if (!isValid) return
 
-        toast({
-            description: 'Спасибо! Ваша заявка была успешно отправлена',
-        })
+        router.push('/contacts')
+        setTimeout(
+            () =>
+                toast({
+                    description: 'Спасибо! Ваша заявка была успешно отправлена',
+                }),
+            200,
+        )
 
-        //const cleanedPhone = normalizePhone(formData.phoneNumber)
+        const cleanedPhone = normalizePhone(formData.phoneNumber)
     }
 
-    // const normalizePhone = (value: string) => {
-    //     return value.replace(/[^\d+]/g, '')
-    // }
+    const normalizePhone = (value: string) => {
+        return value.replace(/[^\d+]/g, '')
+    }
 
     const renderErrors = () => {
         const hasFieldErrors = errors.name || errors.phoneNumber || errors.profession || errors.consent

--- a/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
+++ b/frontend-react/components/mobi/pageMobi/JoinTeamPageMobi/components/JoinTeamMobi.tsx
@@ -6,6 +6,8 @@ import { EnhancedInput } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import PhoneInputMobi from '@/components/mobi/shared/formInput/PhoneInputMobi'
 import Link from 'next/link'
+import { useToast } from '@/context/ToastContext'
+import { Description } from '@radix-ui/react-dialog'
 
 interface IFormData {
     name: string
@@ -38,6 +40,8 @@ const JoinTeamMobi: React.FC = () => {
 
     const fileInputRef = useRef<HTMLInputElement>(null)
     const [selectedFile, setSelectedFile] = useState<File | null>(null)
+
+    const { toast } = useToast()
 
     const openFileDialog = () => {
         fileInputRef.current?.click()
@@ -106,6 +110,10 @@ const JoinTeamMobi: React.FC = () => {
         e.preventDefault()
         const isValid = validateForm()
         if (!isValid) return
+
+        toast({
+            description: 'Спасибо! Ваша заявка была успешно отправлена',
+        })
 
         //const cleanedPhone = normalizePhone(formData.phoneNumber)
     }

--- a/frontend-react/components/ui/toast.tsx
+++ b/frontend-react/components/ui/toast.tsx
@@ -18,10 +18,11 @@ const ToastViewport = React.forwardRef<
             'fixed right-0 z-[100] flex w-auto',
             'top-[180px]',
             'max-h-[calc(100vh-150px-20px)]',
-            'max-md:top-[100px]',
-            'max-sm_xl:top-[90px]',
-            'max-sm_l:top-[80px]',
-            'max-sm:top-[70px]',
+            'md:top-[90px]',
+            'sm_xl:top-[90px]',
+            'sm_l:top-[80px]',
+            'sm_s:top-[80px]',
+            'sm:top-[70px]',
             className,
         )}
         {...props}
@@ -30,25 +31,26 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-    'data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full group pointer-events-auto relative flex items-center justify-center overflow-hidden rounded-full p-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none',
+    'data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=e7d]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full group pointer-events-auto relative flex items-center justify-center overflow-hidden rounded-full shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none',
     {
         variants: {
             variant: {
-                default: 'bg-[#1C1B55] text-white',
+                default:
+                    'break-words bg-[#1C1B55] sm:px-5 sm:py-2 sm_s:px-5 sm_s:py-2 sm_l:px-5 sm_l:py-2 sm_xl:px-5 sm_xl:py-2 md:py-2 text-justify text-white md:px-7 p-6',
                 destructive: 'destructive border-destructive bg-destructive text-destructive-foreground group',
             },
             size: {
                 default: `
-                    sm:max-w-[240px] 
-                    sm_s:max-w-[320px] 
-                    sm_l:max-w-[315px] 
-                    sm_xl:max-w-[360px] 
-                    md:max-w-[420px] 
+                    sm:max-w-[250px]
+                    sm_s:max-w-[313px] 
+                    sm_l:max-w-[313px] 
+                    sm_xl:max-w-[313px] 
+                    md:max-w-[clamp(390px,70vw,430px)] 
                     lg:w-[500px] 
-                    xl:w-[600px] 
+                    xl:w-[650px]
                     2xl:w-[650px] 
                     3xl:w-[800px] 
-                    w-[900px]
+                    w-[900px] 
               `,
             },
         },
@@ -100,14 +102,14 @@ const ToastDescription = React.forwardRef<
             'text-10xl opacity-90',
             '3xl:text-9xl',
             '2xl:text-6xl',
-            'xl:text-4xl',
+            'xl:text-6xl',
             'lg:text-2xl',
-            'md:text-xl',
-            'sm:text-lg',
-            'sm_xl:text-base',
-            'sm_l:text-xs',
-            'sm_s:text-xs',
-            'max-sm:text-[8px]',
+            'md:text-[clamp(16px,3vw,18px)]',
+            'sm:text-xl',
+            'sm_xl:text-xl',
+            'sm_l:text-xl',
+            'sm_s:text-lg',
+            'sm:text-base',
             className,
         )}
         {...props}

--- a/frontend-react/components/ui/toast.tsx
+++ b/frontend-react/components/ui/toast.tsx
@@ -18,8 +18,6 @@ const ToastViewport = React.forwardRef<
             'fixed right-0 z-[100] flex w-auto',
             'top-[180px]',
             'max-h-[calc(100vh-150px-20px)]',
-            'xl:top-[100px]',
-            'lg:top-[100px]',
             'md:top-[90px]',
             'sm_xl:top-[90px]',
             'sm_l:top-[80px]',
@@ -38,7 +36,7 @@ const toastVariants = cva(
         variants: {
             variant: {
                 default:
-                    'break-words bg-[#1C1B55] sm:px-5 sm:py-2 sm_s:px-5 sm_s:py-2 sm_l:px-5 sm_l:py-2 sm_xl:px-5 sm_xl:py-2 md:py-2 text-justify text-white md:px-7 p-6 lg:px-7',
+                    'break-words bg-[#1C1B55] sm:px-5 sm:py-2 sm_s:px-5 sm_s:py-2 sm_l:px-5 sm_l:py-2 sm_xl:px-5 sm_xl:py-2 md:py-2 text-justify text-white md:px-7 p-6',
                 destructive: 'destructive border-destructive bg-destructive text-destructive-foreground group',
             },
             size: {
@@ -48,8 +46,6 @@ const toastVariants = cva(
                     sm_l:max-w-[313px] 
                     sm_xl:max-w-[313px] 
                     md:max-w-[clamp(390px,70vw,430px)] 
-                    lg:w-[600px] 
-                    xl:w-[650px]
                     2xl:w-[650px] 
                     3xl:w-[800px] 
                     w-[900px] 
@@ -104,8 +100,6 @@ const ToastDescription = React.forwardRef<
             'text-10xl opacity-90',
             '3xl:text-9xl',
             '2xl:text-6xl',
-            'xl:text-6xl',
-            'lg:text-5xl',
             'md:text-[clamp(16px,3vw,18px)]',
             'sm:text-xl',
             'sm_xl:text-xl',

--- a/frontend-react/components/ui/toast.tsx
+++ b/frontend-react/components/ui/toast.tsx
@@ -18,6 +18,8 @@ const ToastViewport = React.forwardRef<
             'fixed right-0 z-[100] flex w-auto',
             'top-[180px]',
             'max-h-[calc(100vh-150px-20px)]',
+            'xl:top-[100px]',
+            'lg:top-[100px]',
             'md:top-[90px]',
             'sm_xl:top-[90px]',
             'sm_l:top-[80px]',
@@ -36,17 +38,17 @@ const toastVariants = cva(
         variants: {
             variant: {
                 default:
-                    'break-words bg-[#1C1B55] sm:px-5 sm:py-2 sm_s:px-5 sm_s:py-2 sm_l:px-5 sm_l:py-2 sm_xl:px-5 sm_xl:py-2 md:py-2 text-justify text-white md:px-7 p-6',
+                    'break-words bg-[#1C1B55] sm:px-5 sm:py-2 sm_s:px-5 sm_s:py-2 sm_l:px-5 sm_l:py-2 sm_xl:px-5 sm_xl:py-2 md:py-2 text-justify text-white md:px-7 p-6 lg:px-7',
                 destructive: 'destructive border-destructive bg-destructive text-destructive-foreground group',
             },
             size: {
                 default: `
                     sm:max-w-[250px]
-                    sm_s:max-w-[313px] 
+                    sm_s:max-w-[280px] 
                     sm_l:max-w-[313px] 
                     sm_xl:max-w-[313px] 
                     md:max-w-[clamp(390px,70vw,430px)] 
-                    lg:w-[500px] 
+                    lg:w-[600px] 
                     xl:w-[650px]
                     2xl:w-[650px] 
                     3xl:w-[800px] 
@@ -103,12 +105,12 @@ const ToastDescription = React.forwardRef<
             '3xl:text-9xl',
             '2xl:text-6xl',
             'xl:text-6xl',
-            'lg:text-2xl',
+            'lg:text-5xl',
             'md:text-[clamp(16px,3vw,18px)]',
             'sm:text-xl',
             'sm_xl:text-xl',
             'sm_l:text-xl',
-            'sm_s:text-lg',
+            'sm_s:text-base',
             'sm:text-base',
             className,
         )}


### PR DESCRIPTION
Отображение тоста на разных разрешениях.

sm:
<img width="342" height="137" alt="image" src="https://github.com/user-attachments/assets/018d61fc-f4eb-4cee-a4fa-4e1512003a22" />

sm_s:
<img width="363" height="173" alt="image" src="https://github.com/user-attachments/assets/9502079f-6be0-4b2c-8455-3d3505c97601" />

sm_l:
<img width="412" height="197" alt="image" src="https://github.com/user-attachments/assets/38ecb6e5-d974-459c-9b7f-d16b88d3f1a2" />

sm_xl:
<img width="452" height="194" alt="image" src="https://github.com/user-attachments/assets/54316049-b417-4dab-80ac-9d0019a07949" />

md (426px):
<img width="494" height="204" alt="image" src="https://github.com/user-attachments/assets/84bc19ba-c815-4a73-b419-7729c75b1a87" />

md (768px):
<img width="837" height="227" alt="image" src="https://github.com/user-attachments/assets/a379324f-6378-491a-bcde-d590f835829d" />

2xl:
<img width="1292" height="321" alt="image" src="https://github.com/user-attachments/assets/7dfc48c6-a860-4d8c-822b-e3be38ea8fec" />

3xl:
<img width="1514" height="328" alt="image" src="https://github.com/user-attachments/assets/0112c1fb-2b46-44b3-af94-b4c2740c6cee" />

4xl и выше:
<img width="1902" height="356" alt="image" src="https://github.com/user-attachments/assets/79805820-b640-4435-a020-e6250a9e5c70" />